### PR TITLE
Typo fixes

### DIFF
--- a/book/bread-types/bread-types.tex
+++ b/book/bread-types/bread-types.tex
@@ -43,7 +43,7 @@ bread can be made with all kinds of flour. You can even use
 flour without gluten such as corn or rice flour to make such
 a dough. To make the flat bread a little more fluffy you
 can use a little bit of wheat flour. The developing gluten
-will trap the gasses. During baking theses gasses will
+will trap the gasses. During baking, these gasses will
 inflate the dough.
 
 Another trick to improve the texture of the flat bread is to
@@ -71,9 +71,9 @@ an oven.
   \label{fig:free-standing-loaf-pan}
 \end{figure}
 
-After mixing the ingredients of your dough you can directly
+After mixing the ingredients of your dough, you can directly
 place the dough inside of the loaf pan. This makes the whole
-process simpler as you can skip steps such as shaping the dough.
+process simpler since you can skip steps such as shaping the dough.
 
 To make a great loaf pan bread with little work:
 
@@ -117,7 +117,7 @@ to clean them. With each bake a better patina forms making your
 pan more and more stick resistant.
 
 What's amazing about this type of bread is that it works
-with every flour. Overall time to work the dough is probably
+with every flour. The overall time to work the dough is probably
 less than 5 minutes, making it very easy to integrate
 into your daily routine. Furthermore loaf pans use the space
 in your oven very efficiently. Using the pans I can
@@ -149,7 +149,7 @@ for instance requires you to perform more steps. Mastering this
 technique takes several attempts.
 
 Once the dough is shaped it is proofed again for a certain
-period of time. Once the dough is ready a sharp tool such
+period of time. Once the dough is ready, a sharp tool such
 as a razor blade is used to make an incision into the dough.
 This helps the dough to better open up during the baking process.
 
@@ -164,7 +164,7 @@ for this type of bread in the "\nameref{chapter:wheat-sourdough}" chapter.
 \section{Simple flat bread recipe}
 \label{section:flat-bread-recipe}
 
-If you are just getting started making a flat bread is the
+If you are just getting started, making a flat bread is the
 easiest way to start making great bread at home. With just a
 few steps you can stop buying bread forever. This works with
 every flour, including gluten free options.
@@ -216,7 +216,7 @@ using warm water.
 
 This way you should have around 11g of sourdough ready in the evening. You will have
 the perfect quantity to make a dough for a single person. In case you want to make more
-bread simply multiply the quantities shown in table \ref*{tab:flat-bread-ingredients}.
+bread, simply multiply the quantities shown in table \ref*{tab:flat-bread-ingredients}.
 
 Then in the evening simply mix the ingredients as shown in the table. Your dough
 is going to be ready in the morning. It's typically ready after 6-12 hours. If
@@ -229,7 +229,7 @@ and see what you personally like the most.
 After mixing the ingredients together cover the container in which
 you made the dough. This prevents the dough from drying out and makes
 sure no fruit flies get access. A transparent container will be helpful
-when getting stared. You can better observe the dough and see when
+when getting started. You can better observe the dough and see when
 it is ready.
 
 \begin{figure}[htb!]
@@ -239,27 +239,27 @@ it is ready.
   The image has been provided by Charliefleurene via Wikipedia}
 \end{figure}
 
-If you used the flat bread option with less water look at a size increase
+If you used the flat bread option with less water look at the size increase
 of your dough. The dough should have increased at least 50 percent in size.
-Also look out for bubbles bubbles on the edges of your container.
-When going the pancake route look out for bubbles on the surface of your dough.
+Also look out for bubbles on the edges of your container.
+When going the pancake route, look out for bubbles on the surface of your dough.
 In both cases use your nose to check the scent of your dough. Depending
 on your sourdough starter's microbiome your dough will have 
 dairy, fruity alcoholic notes or vinegary acetic notes. Relying
 on the smell of your dough is best way to judge whether your
 dough is ready or not. Timings are not reliable as they
-depend on your starter and temperature. If your dough
-is ready too soon you can now move it directly to the fridge to bake
+depend on your starter and the temperature. If your dough
+is ready too soon, you can now move it directly to the fridge to bake
 it at a later more convenient time. The low temperature will halt the fermentation
 process\footnote{There are some exceptions. In some rare cases your starter
 might also work at lower temperatures. You might have cultivated low temperature appreciating
-microbes. Regardless though the fermentation
+microbes. Regardless though, the fermentation
 is always slower the colder it gets. A fridge really helps to preserve the state
 of your dough.}
 and your dough is going to be good for several days. The longer you wait the more sour the
 bread is going to be. The fridge is a great option in case you wanted to
 take the dough with you when visiting friends. People are going
-to love you for the freshly baked flat breads or pancakes. If you dare
+to love you for the freshly baked flat breads or pancakes. If you dare,
 you can also taste a little bit of your raw uncooked dough. It is likely
 going to taste relatively sour. I do this frequently to better evaluate the
 state of my doughs.
@@ -277,16 +277,16 @@ If you are completely lazy or don't have time, you could also use older sourdoug
 to make the dough directly without any prior starter feedings. Your sourdough starter
 is going to regrow inside of your dough. The
 final bread might be a bit more on the sour side as the balance of yeast to
-bacteria could be a off. In the table I recommended to use around 5 to 20 percent
+bacteria could be off. In the table I recommended using around 5 to 20 percent
 of sourdough starter based on the flour to make the dough. If you were to follow
-this approach just use around 1 percent and make the dough directly.
+this approach, just use around 1 percent and make the dough directly.
 The dough is probably going to be ready 24 hours later depending on the temperature.
 
-If you wanted to make sweet pan cakes, add some sugar and optional eggs to your dough
+If you wanted to make sweet pancakes, add some sugar and optional eggs to your dough
 now. A good quantity of eggs is around 1 egg per 100 grams of flour.
 Stir your dough a little bit and it is ready to be used. You'll 
 have delicious sweet savory pancakes, the perfect combination. By
-adding the sugar now you make sure that the microbes don't have
+adding the sugar now, you make sure that the microbes don't have
 enough time to fully ferment it. If you had added the sugar
 earlier no sweet flavour would be left 12 hours later.
 
@@ -305,7 +305,7 @@ option opt for around 0.1-0.5cm depending on what you like.
   \centering
   \caption{The crumb of a flat bread made with einkorn as flour. Einkorn
   is very low in gluten and thus does not trap as much CO2 as a wheat based
-  though. To make the dough fluffier use more water or consider adding
+  dough. To make the dough fluffier use more water or consider adding
   more wheat to the mix of your dough.}
 \end{figure}
 
@@ -316,7 +316,7 @@ bake your breads the more of the acidity is going to evaporate. If your
 dough is a bit more on the sour side you can use this trick to balance
 out the acidity. This really depends on which flavor you are looking for.
 
-When making a flat bread I recommend to wrap the baked flat breads
+When making a flat bread I recommend wrapping the baked flat breads
 in a kitchen towel. This way more of the evaporating humidity
 stays inside of your breads. This makes sure your flat breads stay
 nice and fluffy for a longer period after the bake. A similar option is
@@ -330,4 +330,4 @@ Keep a little bit of your unbaked dough. You can use it to make the next
 batch of bread or pancakes for the next day. If you want to bake a few days later, add
 a little bit of water and flour and store this mixture in your fridge
 for as long as you like.\footnote{The starter will stay good for months. If you are out
-for longer consider drying a little bit of your sourdough starter.}
+for longer, consider drying a little bit of your sourdough starter.}

--- a/book/flour-types/flour-types.tex
+++ b/book/flour-types/flour-types.tex
@@ -6,10 +6,10 @@ shop the right flour that you need.
 The most basic flour type is a whole flour. In this case the whole seed has
 been ground to smaller pieces. Sometimes depending on what you want to bake
 the hearty taste of the bran might not be desired. In this case you can use
-whiter flours. With sieves mills remove larger parts of the hull of the seed.
+whiter flours. With sieves, mills remove larger parts of the hull of the seed.
 The seed already contains a pre built germ from the plant waiting to be
 activated. The whitest flour you can get is mostly just the starch part of the seed.
-Depending on which layers are still present names are used to describe the
+Depending on which layers are still present, names are used to describe the
 type of flour.
 
 \begin{table}[htb!]
@@ -32,7 +32,7 @@ In Germany the ash content is used to describe the flours. The lab will burn
 100 grams of flour in the oven. Then afterwards the remaining ash is extracted
 and measured. Depending on the quantity the flour is categorized. If the flour
 is of type 405 then 405 milligrams of ash have remained after burning the
-flour. The more hull parts the flour has the more minerals remain. So the the
+flour. The more hull parts the flour has the more minerals remain. So the
 higher the number the closer the flour is to whole flour. The numbers are
 slightly different between each grain type. Generally though the higher the
 value, the heartier the taste is going to be.
@@ -44,7 +44,7 @@ value, the heartier the taste is going to be.
 \end{figure}
 
 If you compare different grain types there are grains with high gluten, low gluten
-and no gluten. Gluten is what enables bread to have the fluffy consistency.
+and no gluten. Gluten is what enables bread to have its fluffy consistency.
 Without gluten the baked goods wouldn't have the same properties. Managing
 gluten makes the whole bread making process more complex as more steps are involved.
 A dough without gluten doesn't have to be kneaded. Kneading creates
@@ -52,7 +52,7 @@ the gluten bonds. The more you knead the stronger they become. With low
 gluten and no gluten flours you only have to mix the ingredients together, making
 sure you properly homogenize everything. During the duration of the fermentation
 the gluten degrades as the microorganisms metabolize it. When too much gluten
-has been converted your dough will no longer have the previosly wheat like described
+has been converted your dough will no longer have the previously wheat-like described
 structure. For no/low gluten flour your main focus is managing acidity. You do not
 want the final bread to be too sour. You do not have to worry about the gluten
 degradation, removing a huge headache from the equation.
@@ -77,7 +77,7 @@ degradation, removing a huge headache from the equation.
 \end{table}
 
 
-As gluten has a special role the rest of this chapter is dedicated to having a
+As gluten has a special role, the rest of this chapter is dedicated to having a
 closer look at different gluten flours and how to distinguish them. Spelt
 also contains significant amounts of gluten so the same characteristics hold
 true.
@@ -88,10 +88,10 @@ wrongfully classified. The term  \textit{strong or bread} flour in this case
 refers to the properties of the flour. A bread flour is considered to have a
 higher number of protein and thus gluten. This flour is excellent when you
 want to make a sourdough bread as your dough allows for a longer leavening
-period. As described earlier the gluten is consumed by your microorganisms.
+period. As described earlier, the gluten is consumed by your microorganisms.
 The more gluten you have the longer your dough keeps its integrity. If you wanted
 to make a cake you might want to use a flour with less gluten. The gluten binding
-properties might not be desirable. The final cake could have a chewy texture.
+properties might not be desirable since the final cake could have a chewy texture.
 
 In conclusion not every T405, T45 or T00 flour is the same. Depending on the properties
 of plant they have different properties. For that reason some countries like
@@ -105,18 +105,18 @@ baking properties. This type of wheat is typically used as animal feed or
 as fermentable biomass for generators. Category \textbf{E} refers to \textit{Elite} wheat. It's
 the highest quality of wheat. This kind of wheat can be harvested when the
 wheat has grown under optimal conditions. You can compare this to a winery
-that uses only the best grapes to make a reserve wine. Unfortunately this is normally never printed
+that uses only the best grapes to make a reserve wine. Unfortunately, this is normally never printed
 on the packaging of the flour that you buy. You can look out for the protein
-value as a possible indicator. However large mills blend together flours to
+value as a possible indicator. However large mills blend flours together to
 maintain quality throughout the years. Blended flour is also not listed on
 the packaging. It might be that bakeries extract gluten from some flour and
 then mix it in order to create better baking flours.
 
-In italy the so called
+In Italy the so called
 \textbf{W-value} has been introduced to show better how the flour will behave.
 A dough is made and then the resistance of this dough to kneading is measured.
 The more gluten a flour has the more elastic the dough is and the more it will
-resist to kneading. A higher W flour will have a higher gluten content and allow for a longer
+resist kneading. A higher W flour will have a higher gluten content and allow for a longer
 fermentation period. But at the same time it is also harder for the microbes to
 inflate the dough as there is more balloon material. To make an excellent fermented
 product out of a high W flour you will need to have a long fermentation period.
@@ -139,13 +139,13 @@ your dough with more flavor.
 \end{table}
 
 
-Generally when aiming to
+Generally, when aiming to
 bake free standing sourdough bread aim for a higher protein content. If the
 gluten value is relatively low your bread will collapse faster. Baking bread
 is still possible, but it might be easier to use tools such as a loaf pan, or
-to make pan bread.
+to make pan or flat breads.
 
-An additional rarely considered characteristic of good flour is the level of damaging of the
+An additional rarely considered characteristic of good flour is the level of damage to the
 starch molecules. This is a common problem when you are trying to mill your own wheat flours at
 home. Chances are that your home mill is not able to achieve the same results
 a larger mill can. The damaging of the starches is essential to improve the


### PR DESCRIPTION
Mostly typo fixes, a few phrasing changes make things clearer.

I left the 'non pre-heated oven' for the loaf pan breads in the section on bread types (bread-types.text line 83), but suspect it may be a typo as I've always pre-heated the oven for them myself to get as much steam as I can.  If it isn't, I'll have to give it a try sometime.

As ever, feel free to use or discard as you see fit.