### PR TITLE
Fix relase rule in main makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ build_book: build_docker_image
 
 .PHONY: release
 release: build_docker_image
-	docker run -it -v $(PWD):/opt/repo the-sourdough-framework /bin/bash -c "cd /opt/repo/book && make build_pdf"
+	docker run -it -v $(PWD):/opt/repo the-sourdough-framework /bin/bash -c "cd /opt/repo/book && make release"
 
 .PHONY: build_docker_image
 build_docker_image:


### PR DESCRIPTION
The README says `make release` should build the ebooks, but it's building the PDF (same command as in `make build_book`). Maybe this should run `make release` inside the books folder?