### PR TITLE
Minor punctuation, grammatical fixes to Starter Types and Flour Types

### DIFF
--- a/book/flour-types/flour-types.tex
+++ b/book/flour-types/flour-types.tex
@@ -1,13 +1,13 @@
 In this chapter we will have a closer look at different flour types
-and their respective categorization. We will also look a common
+and their respective categorization. We will also look at common
 ways to distinguish different flours of the same type. This way you can more confidently
-shop the right flour that you need.
+purchase the flour that you need.
 
-The most basic flour type is a whole flour. In this case the whole seed has
-been ground to smaller pieces. Sometimes depending on what you want to bake
+The most basic flour type is a whole grain flour. In this case the whole seed has
+been ground to smaller pieces. Sometimes, depending on what you want to bake,
 the hearty taste of the bran might not be desired. In this case you can use
 whiter flours. With sieves, mills remove larger parts of the hull of the seed.
-The seed already contains a pre built germ from the plant waiting to be
+The seed already contains a pre-built germ from the plant waiting to be
 activated. The whitest flour you can get is mostly just the starch part of the seed.
 Depending on which layers are still present, names are used to describe the
 type of flour.
@@ -18,13 +18,13 @@ type of flour.
   \caption{A comparison of the different wheat flour types}
 \end{figure}
 
-In Germany the ash content is used to describe the flours. The lab will burn
+In Germany, the ash content is used to describe the flours. The lab will burn
 100 grams of flour in the oven. Then afterwards the remaining ash is extracted
 and measured. Depending on the quantity the flour is categorized. If the flour
 is of type 405 then 405 milligrams of ash have remained after burning the
-flour. The more hull parts the flour has the more minerals remain. So the
-higher the number the closer the flour is to whole flour. The numbers are
-slightly different between each grain type. Generally though the higher the
+flour. The more hull parts the flour has, the more minerals remain. So the
+higher the number, the closer the flour is to whole flour. The numbers are
+slightly different between each grain type. Generally though, the higher the
 value, the heartier the taste is going to be.
 
 \begin{figure}[htb!]
@@ -33,17 +33,17 @@ value, the heartier the taste is going to be.
   \label{fig:wheat-kernel-overview}
 \end{figure}
 
-If you compare different grain types there are grains with high gluten, low gluten
+If you compare different grain types, there are grains with high gluten, low gluten
 and no gluten. Gluten is what enables bread to have its fluffy consistency.
 Without gluten the baked goods wouldn't have the same properties. Managing
-gluten makes the whole bread making process more complex as more steps are involved.
+gluten makes the whole bread-making process more complex as more steps are involved.
 A dough without gluten doesn't have to be kneaded. Kneading creates
-the gluten bonds. The more you knead the stronger they become. With low
-gluten and no gluten flours you only have to mix the ingredients together, making
-sure you properly homogenize everything. During the duration of the fermentation
+the gluten bonds. The more you knead, the stronger they become. With low-gluten
+and no-gluten flours, you only have to mix the ingredients together, making
+sure you properly homogenize everything. During the duration of the fermentation,
 the gluten degrades as the microorganisms metabolize it. When too much gluten
-has been converted your dough will no longer have the previously wheat-like described
-structure. For no/low gluten flour your main focus is managing acidity. You do not
+has been converted, your dough will no longer have the previously wheat-like described
+structure. For no/low gluten flour, your main focus is managing acidity. You do not
 want the final bread to be too sour. You do not have to worry about the gluten
 degradation, removing a huge headache from the equation.
 
@@ -54,27 +54,27 @@ degradation, removing a huge headache from the equation.
 
 As gluten has a special role, the rest of this chapter is dedicated to having a
 closer look at different gluten flours and how to distinguish them. Spelt
-also contains significant amounts of gluten so the same characteristics hold
+also contains significant amounts of gluten, so the same characteristics hold
 true.
 
 Several recipes call for wheat bread flour. Bread flour can refer to different types
 of flour. It could be a T405 or a T550 in Germany. This is very often
-wrongfully classified. The term  \textit{strong or bread} flour in this case
+wrongfully classified. The term  \textit{strong} or \textit{bread} flour in this case
 refers to the properties of the flour. A bread flour is considered to have a
-higher number of protein and thus gluten. This flour is excellent when you
+higher amount of protein and thus gluten. This flour is excellent when you
 want to make a sourdough bread as your dough allows for a longer leavening
 period. As described earlier, the gluten is consumed by your microorganisms.
-The more gluten you have the longer your dough keeps its integrity. If you wanted
-to make a cake you might want to use a flour with less gluten. The gluten binding
+The more gluten you have, the longer your dough keeps its integrity. If you wanted
+to make a cake, you might want to use a flour with less gluten. The gluten binding
 properties might not be desirable since the final cake could have a chewy texture.
 
-In conclusion not every T405, T45 or T00 flour is the same. Depending on the properties
-of plant they have different properties. For that reason some countries like
+In conclusion, not every T405, T45 or T00 flour is the same. Depending on the properties
+of the plant, they have different properties. For that reason, some countries like
 Germany have introduced additional scales to evaluate the quality of the
 wheat. The category \textbf{A} refers to good quality wheat that can be blended
 with poorer qualities to improve the flour. The category \textbf{B} refers to
 average wheat that can be used to create different baked goods. Category \textbf{C}
-is used for wheat that has poor baking qualities. This could happen for instance
+is used for wheat that has poor baking qualities. This could happen, for instance,
 if the wheat already started to sprout and thus lost some of its desirable
 baking properties. This type of wheat is typically used as animal feed or
 as fermentable biomass for generators. Category \textbf{E} refers to \textit{Elite} wheat. It's
@@ -82,17 +82,17 @@ the highest quality of wheat. This kind of wheat can be harvested when the
 wheat has grown under optimal conditions. You can compare this to a winery
 that uses only the best grapes to make a reserve wine. Unfortunately, this is normally never printed
 on the packaging of the flour that you buy. You can look out for the protein
-value as a possible indicator. However large mills blend flours together to
+value as a possible indicator. However, large mills blend flours together to
 maintain quality throughout the years. Blended flour is also not listed on
 the packaging. It might be that bakeries extract gluten from some flour and
 then mix it in order to create better baking flours.
 
-In Italy the so called
+In Italy the so-called
 \textbf{W-value} has been introduced to show better how the flour will behave.
-A dough is made and then the resistance of this dough to kneading is measured.
-The more gluten a flour has the more elastic the dough is and the more it will
+A dough is made, and then the resistance of this dough to kneading is measured.
+The more gluten a flour has, the more elastic the dough is, and the more it will
 resist kneading. A higher W flour will have a higher gluten content and allow for a longer
-fermentation period. But at the same time it is also harder for the microbes to
+fermentation period. But at the same time, it is also harder for the microbes to
 inflate the dough as there is more balloon material. To make an excellent fermented
 product out of a high W flour you will need to have a long fermentation period.
 The long fermentation period also means that your microbes will enrich
@@ -105,28 +105,28 @@ your dough with more flavor.
 \end{figure}
 
 Generally, when aiming to
-bake free standing sourdough bread aim for a higher protein content. If the
-gluten value is relatively low your bread will collapse faster. Baking bread
+bake freestanding sourdough bread, aim for a higher protein content. If the
+gluten value is relatively low, your bread will collapse faster. Baking bread
 is still possible, but it might be easier to use tools such as a loaf pan, or
 to make pan or flat breads.
 
-An additional rarely considered characteristic of good flour is the level of damage to the
+An additional, rarely considered characteristic of good flour is the level of damage to the
 starch molecules. This is a common problem when you are trying to mill your own wheat flours at
 home. Chances are that your home mill is not able to achieve the same results
 a larger mill can. The damaging of the starches is essential to improve the
 properties of the dough. You will have a better gelatinization and water
 absorption with properly damaged starch \cite{starch+damage+flour}. As more
-starch is damaged the surface area increases. This improves how water connects with the flour.
+starch is damaged, the surface area increases. This improves how water interacts with the flour.
 This also provides a larger surface that your microbes can use to attack the molecules 
 and start the fermentation process.
 
 I am still
 yet to find a good way of milling my own flour at home. Even after trying to
-mill the flour 10 times with short breaks I was not able to achieve the same
+mill the flour 10 times with short breaks, I was not able to achieve the same
 properties as with commercially milled flour. The doughs I would make felt
-good, maybe a bit coarse. Then during baking however the doughs would start to
+good, though maybe a bit coarse. Then during baking, however, the doughs would start to
 degas quickly and turn into very flat breads. I have had great success though when
-utilizing home milled flour together with a loaf pan or as a pan bread. If you
-have found great ways to work with home milled flour please reach out. The potential
-of using home milled flours is huge. It would enable even distant communities
+utilizing home-milled flour together with a loaf pan or as a pan bread. If you
+have found great ways to work with home-milled flour, please reach out. The potential
+of using home-milled flours is huge. It would enable even distant communities
 to grow their own wheat and be able to produce amazing freshly baked bread.

--- a/book/sourdough-starter/sourdough-starter-types.tex
+++ b/book/sourdough-starter/sourdough-starter-types.tex
@@ -235,7 +235,7 @@ up to 60 percent. All the ingredients should mix together very well. There
 should be no crumbly flour left. This is a common mistake I have seen when
 people tried to make the stiff starter. Yes it should be dry, but not to a
 point where it is a brick of cement. If you have ever made a pasta dough, this is
-exactly the same way the dough should feel.
+exactly the same way the stiff starter should feel.
 
 To evaluate whether your stiff starter is ready, look for a dome. Also look for
 pockets of air on the edges of your container. Use your nose to smell the
@@ -252,7 +252,7 @@ water you are about to use for your dough. This will make mixing a lot easier.
 
 \section{Lievito madre or pasta madre}
 
-The Lievito madre also known as pasta madre belongs to the same category as
+The lievito madre, also known as pasta madre, belongs to the same category as
 the stiff sourdough starter. After conducting hours of research, I could not
 find a difference in pasta madre and lievito madre. Both of terms seem to be
 used interchangeably in literature.
@@ -265,7 +265,7 @@ from dried fruits, you sometimes lack the bacterial part of the fermentation.
 The acidity is very important in order to clean your starter from possible
 pathogens. If you decide to make your starter from fruits, make sure it also
 acidifies properly when making a dough. A tool such as a pH meter can be of
-optimal help. Generally the lower the pH, the higher the acidity. The acidity
+optimal help. Generally, the lower the pH, the higher the acidity. The acidity
 should be below 4.2 to know that your starter produces sufficient acidity.
 
 Some bakers cleanse the lievito madre in a bath of water. This is supposed to

--- a/book/sourdough-starter/sourdough-starter-types.tex
+++ b/book/sourdough-starter/sourdough-starter-types.tex
@@ -10,18 +10,18 @@ traits.
   \label{tab:starter-types-comparison}
 \end{table}
 
-Depending on the flour you have at hand the type of starter changes. With more
+Depending on the flour you have at hand, the type of starter changes. With more
 bacterial activity you have more gluten consumption of your microbes. So if
-you want to bake a free standing loaf you need a flour with more gluten. The
-more gluten you have the more of it can be broken down whilst still maintaining
+you want to bake a free standing loaf, you need a flour with more gluten. The
+more gluten you have, the more of it can be broken down whilst still maintaining
 dough integrity. If you live in a country where the climate to grow wheat
 isn't ideal and you only have weaker flours, then a stiff sourdough starter
 could be advised. The stiff sourdough starter will improve yeast activity and
 reduce bacterial activity. If you are a chaser of a very sour bread and have a
 very strong wheat flour then you can try to play with a liquid sourdough
 starter. The key difference between all of the starters is how much water
-is used in the starter. The regular starter having a 1:1 relationship of flour
-to water. The liquid starter has a 5:1 water to flour ratio and the stiff
+is used in the starter. The regular starter has a 1:1 relationship of flour
+to water. The liquid starter has a 5:1 water-to-flour ratio, and the stiff
 starter has half the flour as water.
 
 \begin{figure}[!htb]
@@ -36,28 +36,28 @@ starter has half the flour as water.
 You can change your starter type by just adjusting the feeding ratio of how
 much flour and water you use. I frequently changed my starter type from
 regular to liquid and then back to a stiff starter. After changing the
-environment of your microbes apply feedings at the same ratio over a couple of
+environment of your microbes, apply feedings at the same ratio over a couple of
 days so that they can adapt to the new environment. I could already see
 changes after a single feeding, but I recommend 2 to 3 feedings, one feeding per
-day to see a stronger effect.
+day, to see a stronger effect.
 
 Your dough is generally just a big sourdough starter. So your starter is going
 to adapt and regrow inside of your main dough. But you can influence the
 properties that your starter carries over to your main dough. If you have more
-bacterial fermentation then your dough will also have slightly more bacterial
-fermentation. If you have more yeast fermentation then your main dough will
+bacterial fermentation, then your dough will also have slightly more bacterial
+fermentation. If you have more yeast fermentation, then your main dough will
 have slightly more yeast fermentation. This is important to know when you are
 working with a more mature unfed starter. Let's say your starter had last been
-fed 48 hours ago, then chances are your bacteria is very active while the
+fed 48 hours ago. Chances are that your bacteria is very active while the
 yeast could be dormant. In such a case you can skip feeding your starter
-before making another dough. Just use a very tiny amount of starter. For 1000g
-of flour I would take around 10g of starter (1 percent in terms of baker's
+before making another dough. Just use a very tiny amount of starter. For 1000 g
+of flour I would take around 10 g of starter (1 percent in terms of baker's
 math). If my starter is very young and had just been fed 6 to 8 hours ago I might
 end up going up to 20 percent of starter. Remember that your dough is nothing
 else other than a big starter. It will tremendously help you to figure out
 your best next steps.
 
-When using such a low inoculation rate (1 percent) you need to use stronger
+When using such a low inoculation rate (1 percent), you need to use stronger
 flour when making wheat-based doughs. Your flour naturally breaks down due
 to enzymatic activity. It might take 24 hours for the starter to re-grow
 inside of your bread dough. At the same time, the enzymatic activity might
@@ -78,26 +78,26 @@ a longer fermentation before most gluten is broken down.
 The regular sourdough starter is made at a hydration of around 100 percent.
 This means the starter has equal parts of flour and water. This is the most
 common and must universal sourdough starter there is. The starter has a good
-balance of yeast and bacteria. After a feeding the volume increases and
-increases. After it reached a certain peak it will start to collapse again.
+balance of yeast and bacteria. After a feeding, the volume increases and
+increases. After it reached a certain peak, it will start to collapse again.
 
 The best way to judge whether the starter is ready is to look at signs such as
 pockets on the edges of your container. Also use the nose to to evaluate the
 smell of your starter. If you feel that the starter doesn't perform in a
-desirable way chances are that your yeast and bacteria ratios are off. In that
-case frequently daily feedings using a 1:5:5 (starter:flour:water) ratio will
+desirable way, chances are that your yeast and bacteria ratios are off. In that
+case frequent daily feedings using a 1:5:5 (starter:flour:water) ratio will
 help.
 
 The starter is perfect to use when utilizing stronger wheat or spelt flours.
 It also nicely works with rye, emmer or einkorn. If you only have a weak flour
-at hand with less gluten this starter might cause issue. As you tend to have
-quite some bacterial activity gluten is going to be broken down fast. When
-using the starter use around 1 to 20 percent starter based on the flour of your
+at hand with less gluten, this starter might cause issues. As you tend to have
+quite some bacterial activity, gluten is going to be broken down fast. When
+using the starter, use around 1 to 20 percent starter based on the flour of your
 dough.
 
-Depending on the bacteria cultivated your starter either has a lactic (dairy),
-a vinegary (acetic) or mix of both flavour profile. You can adjust your
-starter's flavour by changing the type to a liquid starter.
+Depending on the bacteria cultivated, your starter either has a lactic (dairy),
+a vinegary (acetic) or mix of both flavor profile. You can adjust your
+starter's flavor by changing the type to a liquid starter.
 
 \section{Liquid starter}
 \label{section:liquid-starter}
@@ -117,42 +117,42 @@ starter's flavour by changing the type to a liquid starter.
   \includegraphics{figures/fig-liquid-starter-conversion.pdf}
   \caption{The process to convert your regular or stiff starter into a liquid starter. The whole
   process takes around 3 days. The longer you maintain your starter at the
-  suggested hydration level the more adapted your microorganisms become. It is recommended
+  suggested hydration level, the more adapted your microorganisms become. It is recommended
   to keep a backup of your original starter as the liquid environment will select
-  an-aerobic microorganisms. This boosts bacteria that create lactic acid rather
+  anaerobic microorganisms. This boosts bacteria that create lactic acid rather
   than acetic acid. The resulting acidity will be perceived as milder.}
   \label{fig:liquid-starter-conversion}
 \end{figure}
 
 The liquid starter is made at a hydration of around 500 percent. This means
-the starter has way more water than flour. The additional layer of water on
+the starter has much more water than flour. The additional layer of water on
 top of the flour changes the microbiome of your starter.
 
-By introducing this layer of water less oxygen is available throughout the
+By introducing this layer of water, less oxygen is available throughout the
 course of fermentation. This means that your starter will no longer be
 producing acetic acid. The heterofermentative lactic acid bacteria will thrive
 in this environment. This is a neat little trick to change your starter's
-flavour profile from vinegary to lactic. Your starter is going to develop
-dairy creamy notes. Interesting when changing the hydration again your starter
+flavor profile from vinegary to lactic. Your starter is going to develop
+dairy creamy notes. Interestingly, when changing the hydration again, your starter
 is going to maintain the liquid starter flavor profile, but then benefit again
 from enhanced yeast activity. The liquid starter conversion is non reversible.
-So ideally keep a backup of your starter before.
+So ideally keep a backup of your stiff or regular starter.
 
 To commence with the
-conversion simply take around 1 gram of your starter, mix with 5g flour and
-25g water. Stir everything together properly. After a few minutes the flour is
+conversion, simply take around 1 gram of your starter, mix with 5 g flour and
+25 g water. Stir everything together properly. After a few minutes the flour is
 going to start settling in at the bottom of your jar. Repeat this process over
-a few days. Shake the starter gently to see if you can see tiny CO2 bubbles
+a few days. Shake the starter gently to see if you can see tiny CO_{2} bubbles
 moving in the liquid. This is a good sign that your starter is ready. Use your
 nose to smell the starter. It should have a creamy dairy flavor note.
 
-As you have more bacterial activity this starter works best with a very strong
+As you have more bacterial activity, this starter works best with a very strong
 flour that can withstand a long fermentation period. Using this starter with a
-weak wheat flour will not work. If you do not care about baking a free
-standing loaf then you can easily use this starter together with a loaf pan.
+weak wheat flour will not work. If you do not care about baking a freestanding loaf,
+then you can easily use this starter together with a loaf pan.
 This starter also works great when making a hearty pancake dough. To use it I
 shake the starter container until I see all ingredients are homogenized. Then
-I use around 5 percent of it in terms of baker's math. So for 1000g of flour
+I use around 5 percent of it in terms of baker's math. So for 1000 g of flour
 that's around 50 grams of liquid starter. As it is very liquid you have to
 include the 50 grams in your liquid calculation. I typically treat the starter
 directly as liquid in the recipes. So if the recipe calls for 600 grams of water
@@ -165,19 +165,19 @@ has a mold problem then the liquid conversion could be the remedy. Take a
 piece of your starter where you suspect no mold growth. Apply the conversion
 as mentioned before. The mold will likely sporulate as it runs out of food.
 With each new feeding you are reducing the mold spores. The spores can no
-longe reactivate as they can not do so in the anaerobic conditions.
+longer reactivate as they can not do so in the anaerobic conditions.
 
 The liquid on top of your starter is an excellent resource that you could use
 to make sauces. If you feel you would like to add a little bit of acidity,
 drain the liquid part on your starter and use it. I have used it numerous
-times to make lactofermented hot sauces.
+times to make lacto-fermented hot sauces.
 
 \section{Stiff starter}
 \label{section:stiff-starter}
 
 \begin{figure}[!htb]
   \includegraphics[width=\textwidth]{sourdough-starter-stiff.jpg}
-  \caption{A stiff sourdough starter that I used to make a Stollen dough for christmas. Note
+  \caption{A stiff sourdough starter that I used to make a Stollen dough for Christmas. Note
   the bubbles on the edge of the container. The dough does not fall out of the jar.}
   \label{fig:stiff-sourdough-starter}
 \end{figure}
@@ -190,7 +190,7 @@ around 50 to 60 percent. So for 100 grams of flour you are using around 50 to
   \includegraphics{figures/fig-stiff-starter-conversion.pdf}
   \caption{The process to convert your regular starter into a stiff starter. The whole
   process takes around 3 days. The longer you maintain your starter at the
-  suggested hydration level the more adapted your microorganisms become. The
+  suggested hydration level, the more adapted your microorganisms become. The
   stiff starter boosts the yeast activity of your sourdough starter.
   The guide uses a 50 percent hydration level for the starter. If the dough is too stiff
   consider increasing this to 60 percent.}
@@ -198,29 +198,29 @@ around 50 to 60 percent. So for 100 grams of flour you are using around 50 to
 \end{figure}
 
 In the stiffer environment the yeast thrives more. This means you will have
-more CO2 production and less acid production. In my tests this is a game
+more CO_{2} production and less acid production. In my tests this is a game
 changer especially if you are using weaker gluten flours. The wheat flours in
-my home country Germany tend to be lower in gluten. For wheat to build gluten warm conditions
-are preferred (SOURCE NEEDED). When following recipes from other bakers I
+my home country of Germany tend to be lower in gluten. For wheat to build gluten, warm conditions
+are preferred (SOURCE NEEDED). When following recipes from other bakers, I
 could never achieve similar results. When following timings my doughs would
 simply collapse and become super sticky. Only when I started to buy more
-expensive wheat flour my results started to change. As not everyone can afford
-these special baking flours and due their limited availability I stumbled upon the
+expensive wheat flour did my results start to change. As not everyone can afford
+these special baking flours and due their limited availability, I stumbled upon the
 stiff sourdough starter. I made several tests where I used the same amount of
 starter and flour. I only changed the hydration between all the starters. I
 would then proceed and place a balloon on top of each of the jars. The stiff
-starter jar was clearly inflated the most. On place 2 the regular starter
-followed. On place three the liquid starter followed with way less CO2
+starter jar was clearly inflated the most. The regular starter
+followed in second place. The liquid starter finished in third place with far less CO_{2}
 production.
 
 \begin{figure}[!htb]
   \includegraphics[width=\textwidth]{stollen}
-  \caption{A German christmas stollen made with a stiff starter instead of yeast}
+  \caption{A German Christmas stollen made with a stiff starter instead of yeast}
   \label{fig:stollen}
 \end{figure}
 
 I then proceeded and bought a cheap low cake flour in my nearby supermarket.
-This flour before had caused me massive headache before. I made a sourdough bread
+This flour before had caused me massive headaches before. I made a sourdough bread
 exactly how I would normally do. I had to reduce the hydration a bit as a low
 gluten flour does not soak up as much water. Then I replaced the starter with
 the stiff starter. The dough felt amazing and was suddenly able to withstand a
@@ -229,23 +229,23 @@ very mild. I am still yet to find a proper explanation why the yeast part of
 the dough is more active. Maybe it is not. It could also be that the bacteria
 is inhibited by the lack of water.
 
-When making the stiff sourdough starter start with using around 50 percent
+When making the stiff sourdough starter, start with using around 50 percent
 water. If you are using a whole wheat flour, or a strong flour consider going
 up to 60 percent. All the ingredients should mix together very well. There
 should be no crumbly flour left. This is a common mistake I have seen when
 people tried to make the stiff starter. Yes it should be dry, but not to a
-point where it is a brick of cement. If you ever made a pasta dough, this is
-exactly the same way how the dough should feel like.
+point where it is a brick of cement. If you have ever made a pasta dough, this is
+exactly the same way the dough should feel.
 
-To evaluate whether your stiff starter is ready look for a dome. Also look for
+To evaluate whether your stiff starter is ready, look for a dome. Also look for
 pockets of air on the edges of your container. Use your nose to smell the
-starter. It should have a mild smell. It also tends to smell way more
+starter. It should have a mild smell. It also tends to smell much more
 alcoholic than the other starters.
 
-When using the starter use around 1 to 20 percent depending on the ripeness of
+When using the starter, use around 1 to 20 percent depending on the ripeness of
 your starter. In summer times I typically use around 10 percent and in winter
 times around 20 percent. This way you can also control the fermentation speed.
-Mixing the starter can be a little bit annoying as it hardly homogenises with
+Mixing the starter can be a little bit annoying as it hardly homogenizes with
 the rest of the dough. In this case you can try to dissolve the starter in the
 water you are about to use for your dough. This will make mixing a lot easier.
 
@@ -253,53 +253,53 @@ water you are about to use for your dough. This will make mixing a lot easier.
 \section{Lievito madre or pasta madre}
 
 The Lievito madre also known as pasta madre belongs to the same category as
-the stiff sourdough starter. After conducting hours of research I could not
+the stiff sourdough starter. After conducting hours of research, I could not
 find a difference in pasta madre and lievito madre. Both of terms seem to be
 used interchangeably in literature.
 
 In many recipes this starter is made directly
 from dried or fresh fruits. You can make a starter also from leaves from your
-garden. As described before the wild yeast and bacteria consume the glucose
-from the plants leaves. All the options work. When making a starter directly
-from dried fruits you sometimes lack the bacterial part of the fermentation.
+garden. As described before, the wild yeast and bacteria consume the glucose
+from the plants' leaves. All the options work. When making a starter directly
+from dried fruits, you sometimes lack the bacterial part of the fermentation.
 The acidity is very important in order to clean your starter from possible
-pathogens. If you decide to make your starter from fruits make sure it also
+pathogens. If you decide to make your starter from fruits, make sure it also
 acidifies properly when making a dough. A tool such as a pH meter can be of
-optimal help. Generally the lower the pH the higher the acidity. The acidity
+optimal help. Generally the lower the pH, the higher the acidity. The acidity
 should be below 4.2 to know that your starter produces sufficient acidity.
 
 Some bakers cleanse the lievito madre in a bath of water. This is supposed to
 remove excess acidity. In my own experiments I have not been able to confirm
 this methodology. The acidity remains the same. The only reason this could
-make sense is if you also tried to boost anaerobic microorganisms. However then the
+make sense is if you also tried to boost anaerobic microorganisms. However, then the
 starter would need to remain in this environment for quite some time and not just
 a few hours.
 
 Baking with sourdough is simple. It's just flour and water. When seeing a recipe
-from an experienced baker you wonder, wait, that's it? There is nothing more
-to it? I feel that this might be the reason why some bakers have so complicated
+from an experienced baker you wonder, Wait, that's it? There is nothing more
+to it? I feel that this might be the reason why some bakers have such complicated
 feeding procedures. They resort to several feedings per day at a certain given ratio.
 This makes the baker feel a little more elitist. Of course over time as
-more and more people follow this procedure it becomes a self fulfilling prophecy.
-The more experienced you become the higher the chances are that a bogus starter
+more and more people follow this procedure, it becomes a self fulfilling prophecy.
+The more experienced you become, the higher the chances are that a bogus starter
 feeding guide will reward you with beautiful results. The reason however is
 not in the starter routine. The reason is that you better understand the fermentation
 and become better at reading the signs of your dough.
 
-If I had one starter type to choose I would go for the stiff starter. In many cases
+If I had one starter type to choose, I would go for the stiff starter. In many cases
 it will provide you with consistent great results with little effort.
-In my experience you can make any yeast based dough and just replace
+In my experience you can make any yeast-based dough and just replace
 the yeast directly with the stiff sourdough starter. You will be able
 to achieve even better results with the stiff starter.
 
-Lastly no matter which starter type you choose, you can control how sour
-you want your dough to be. The longer you push the fermentation the more
+Lastly, no matter which starter type you choose, you can control how sour
+you want your dough to be. The longer you push the fermentation, the more
 acidity is going to be piled up. The only difference is that for a given
-volume increase the stiff starter will produce the least acidity. So for a
-volume increase of 100 percent, the liquid starter has produced most acidity,
+volume increase, the stiff starter will produce the least acidity. So for a
+volume increase of 100 percent, the liquid starter has produced the most acidity,
 followed by the regular starter and then the stiff starter. If you wait long
-enough the stiff starter will have produced the same amount of acidity as the
-other starters. But before doing so it also has produced a lot more CO2. If
-you like the sour flavour you have to push your fermentation longer. This also
+enough, the stiff starter will have produced the same amount of acidity as the
+other starters. But before doing so it will have also produced a lot more CO_{2}. If
+you like the sour flavor, you have to push your fermentation longer. This also
 means you either need to bake in a loaf pan or have a very strong gluten flour
 that is able to withstand long fermentation times.


### PR DESCRIPTION
## Ch 4, Sourdough Starter Types
Cleaned up phrasing, added commas as needed
I did not change whether grams was spelled out or abbreviated; I only fixed where it said 50g rather than 50 g

## Ch 5, Flour Types
Americans call it whole grain flour; Brits call it whole meal flour, but neither usually says "whole flour"

# Most common corrections throughout
(You can think of this as the beginnings of my personal, doc-specific style guide)
* Dependent clauses of more than 5 words that begin a sentence (e.g., "_Because_ I went to the store", "_Since_ he had to leave early", "_If_ you are making a lot of bread", "_When_ he found the body") need a comma before the main part of the sentence.  Phrases with fewer words may still want a comma to be more readable.
* When units are abbreviated, there still needs to be a space in between the numeral and the unit (e.g., 50 g)
* Add subscript for chemical formulas: `CO2` -> `CO_{2}`
* I am substituting "much" in most cases of the word "way" in order to be less casual.  E.g., "way more acidic" vs. "much more acidic"
* Phrases such as "The more the x, the less y" need a comma separating the two ideas
* Added a comma for initial adverbs such as however, lastly, furthermore, etc. (not everyone does this, but I noticed that the book so far usually uses commas here, so I'm just working to make the book internally consistent)