### PR TITLE
Export figures feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ that it will reach more people all over the world without
 budget constraints.
 
 If you would like to contribute with a small donation you can do so
-via my [ko-fi page.](https://breadco.de/book). This will help me
+via my [ko-fi page.](https://breadco.de/book) This will help me
 to cover costs related to running the-bread-code and allow me
 to work more updates for this book.
 

--- a/book/figures/export_figures.sh
+++ b/book/figures/export_figures.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+for i in *.pdf
+do
+  docker run -v $(pwd):/imgs dpokidov/imagemagick -density 900 -trim /imgs/$i -quality 100 /imgs/$i.png
+  rename 's/pdf.png/png/' *.png
+  rename 's/fig-/figure-/' *.png
+done
+

--- a/book/makefile
+++ b/book/makefile
@@ -4,16 +4,31 @@ build_pdf: clean figures tables
 	biber book
 	pdflatex book.tex
 
+.PHONY: clean_figures
+clean_figures:
+	cd figures
+	rm -rf figures/*.aux
+	rm -rf figures/*.fdb_latexmk
+	rm -rf figures/*.fls
+	rm -rf figures/*.log
+	rm -rf figures/*.pdf
+	rm -rf figures/*.png
+
+.PHONY: export_figures
+# Requires that you have docker running on your computer.
+export_figures:
+	cd figures/ && bash export_figures.sh
+
 .PHONY: figures
-figures:
-	cd figures && find . -name "fig-*.tex" -exec pdflatex '{}' \; && cd ../
+figures: clean_figures
+	cd figures && find . -name "fig-*.tex" -exec pdflatex '{}' \;
 
 .PHONY: tables
 tables:
-	cd tables && find . -name "table-*.tex" -exec pdflatex '{}' \; && cd ../
+	cd tables && find . -name "table-*.tex" -exec pdflatex '{}' \;
 
 .PHONY: clean
-clean:
+clean: clean_figures
 	rm -f book.blg
 	rm -f book.bbl
 	rm -f book.aux
@@ -47,12 +62,6 @@ clean:
 	rm -f *.pdf
 	rm -f output.log
 	rm -f content.opf
-	rm -rf figures/*.aux
-	rm -rf figures/*.fdb_latexmk
-	rm -rf figures/*.fls
-	rm -rf figures/*.log
-	rm -rf figures/*.pdf
-	rm -rf figures/*.png
 	find . -name "*.xbb" | xargs rm -f
 	rm -rf release/
 


### PR DESCRIPTION
This adds a `make export_figures` command which exports all the flow charts into nicely looking pngs. The command requires that you have docker running locally.

Example:
![figure-dividing-preshaping](https://user-images.githubusercontent.com/816859/228845719-ba75714d-0a4b-496b-b7cd-75edc59d3d8d.png)
