### PR TITLE
Fix no such file error when running docker via sudo

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,10 +1,10 @@
 .PHONY: build_book
 build_book: build_docker_image
-	docker run -it -v $(PWD):/opt/repo the-sourdough-framework /bin/bash -c "cd /opt/repo/book && make build_pdf"
+	docker run -it -v .:/opt/repo the-sourdough-framework /bin/bash -c "cd /opt/repo/book && make build_pdf"
 
 .PHONY: release
 release: build_docker_image
-	docker run -it -v $(PWD):/opt/repo the-sourdough-framework /bin/bash -c "cd /opt/repo/book && make release"
+	docker run -it -v .:/opt/repo the-sourdough-framework /bin/bash -c "cd /opt/repo/book && make release"
 
 .PHONY: build_docker_image
 build_docker_image:


### PR DESCRIPTION
When a user is not a member of the `docker` group they need to run the build with sudo - `sudo make`.

This fails however as `$(PWD)` resolves to nothing and you get the following error

```
Successfully tagged the-sourdough-framework:latest
docker run -it -v WD:/opt/repo the-sourdough-framework /bin/bash -c "cd /opt/repo/book && make build_pdf"
/bin/bash: line 1: cd: /opt/repo/book: No such file or directory
make: *** [makefile:3: build_book] Error 1
```

Replacing `$(PWD)` with `.` means the same thing but allows the builds to be run with sudo 