### PR TITLE
Ebook improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,5 @@ book/book-mobi/
 book/book-azw3/
 *.bak
 book_sans_serif/
+release_sans_serif/
 *.opf

--- a/book/book-ebook.css
+++ b/book/book-ebook.css
@@ -1,0 +1,8 @@
+.figure {
+    max-width: 100% !important;
+}
+.figure img {
+    max-width: 100% !important;
+    object-fit: contain !important;
+    width: auto !important;
+}

--- a/book/book-ebook.css
+++ b/book/book-ebook.css
@@ -1,8 +1,9 @@
 .figure {
-    max-width: 100% !important;
+    max-width: 100%;
 }
 .figure img {
     max-width: 100% !important;
-    object-fit: contain !important;
-    width: auto !important;
+    height: auto;
+    object-fit: contain;
+    width: auto;
 }

--- a/book/book.mk4
+++ b/book/book.mk4
@@ -1,0 +1,8 @@
+local filter  = require "make4ht-filter"
+local changePath = function(s) return s:gsub("%./images//","images/") end
+local removeHeight = function(s) return s:gsub("height=\"390\"","") end
+local removeWidth = function(s) return s:gsub("width=\"390\"","") end
+local removeFixedSettings = function(s) return removeWidth(removeHeight(changePath(s))) end
+local process = filter{removeFixedSettings}
+Make:htlatex()
+Make:match("html$",process)

--- a/book/book.mk4
+++ b/book/book.mk4
@@ -1,8 +1,9 @@
 local filter  = require "make4ht-filter"
 local changePath = function(s) return s:gsub("%./images//","images/") end
-local removeHeight = function(s) return s:gsub("height=\"390\"","") end
-local removeWidth = function(s) return s:gsub("width=\"390\"","") end
-local removeFixedSettings = function(s) return removeWidth(removeHeight(changePath(s))) end
+local removeHeight = function(s) return s:gsub('height="%d+"', '') end
+local removeWidth = function(s) return s:gsub('width="%d+"', '') end
+local removeMaxWidth = function(s) return s:gsub(' max-width: %d+px;', '') end
+local removeFixedSettings = function(s) return removeMaxWidth(removeWidth(removeHeight(changePath(s)))) end
 local process = filter{removeFixedSettings}
 Make:htlatex()
 Make:match("html$",process)

--- a/book/makefile
+++ b/book/makefile
@@ -115,4 +115,7 @@ build_ebook: make_release_dir
 	find . -name "*.png" | xargs ebb -x
 	tex4ebook -c tex4ebook.cfg -f epub book.tex
 	tex4ebook -c tex4ebook.cfg -f mobi book.tex
+	# not sure why, but I hvae to generate the mobi twice for the
+	# release command to properly work.
+	tex4ebook -c tex4ebook.cfg -f mobi book.tex
 	tex4ebook -c tex4ebook.cfg -f azw3 book.tex

--- a/book/makefile
+++ b/book/makefile
@@ -111,8 +111,6 @@ release_sans_serif: make_release_dir
 
 .PHONY: build_ebook
 build_ebook: make_release_dir
-	find . -name "*.jpg" | xargs ebb -x
-	find . -name "*.png" | xargs ebb -x
 	tex4ebook -c tex4ebook.cfg -f epub book.tex
 	tex4ebook -c tex4ebook.cfg -f mobi book.tex
 	# not sure why, but I hvae to generate the mobi twice for the

--- a/book/tex4ebook.cfg
+++ b/book/tex4ebook.cfg
@@ -3,7 +3,7 @@
 \Configure{DocumentLanguage}{en}
 \Configure{OpfScheme}{URI}
 \Configure{UniqueIdentifier}{https://the-bread-code.io}
-\Configure{AddCss}(book-ebook.css)
+\Configure{AddCss}{book-ebook.css}
 \Configure{CoverMimeType}{image/jpeg}
 \CoverMetadata{images/cover-page.jpg}
 \EndPreamble

--- a/book/tex4ebook.cfg
+++ b/book/tex4ebook.cfg
@@ -3,6 +3,7 @@
 \Configure{DocumentLanguage}{en}
 \Configure{OpfScheme}{URI}
 \Configure{UniqueIdentifier}{https://the-bread-code.io}
+\Configure{AddCss}(book-ebook.css)
 \Configure{CoverMimeType}{image/jpeg}
 \CoverMetadata{images/cover-page.jpg}
 \EndPreamble


### PR DESCRIPTION
Removes fixed height and width from the resulting HTML and adds an additional css for the ebook formats. This is related to #59. It doesn't fix the apple books though.