### PR TITLE
Makefile improvements

### DIFF
--- a/book/makefile
+++ b/book/makefile
@@ -123,7 +123,7 @@ release_sans_serif: make_release_dir
 	cp release_sans_serif/release/TheBreadCode-The-Sourdough-Framework.azw3 release/TheBreadCode-The-Sourdough-Framework-sans-serif.azw3
 
 .PHONY: build_ebook
-build_ebook: make_release_dir
+build_ebook: make_release_dir build_pdf
 	tex4ebook -c tex4ebook.cfg -f epub book.tex
 	tex4ebook -c tex4ebook.cfg -f mobi book.tex
 	# not sure why, but I hvae to generate the mobi twice for the

--- a/book/makefile
+++ b/book/makefile
@@ -1,5 +1,6 @@
 LATEX := latexmk -cd -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make
 CLEAN := latexmk -cd -c
+PROPER := latexmk -cd -C
 
 %.pdf: %.tex
 	$(LATEX) $<
@@ -21,16 +22,20 @@ build_pdf: $(TGT_FIGURES) $(TGT_TABLES) book.tex
 .PHONY: clean_tables
 clean_tables:
 	$(CLEAN) $(SRC_TABLES)
-	cd tables/ 
-	- rm -f $(TGT_TABLES)
-	- rm -f *.png
+
+.PHONY: proper_tables
+proper_tables: clean_tables
+	$(PROPER) $(SRC_TABLES)
+	- rm -f tables/*.png
 
 .PHONY: clean_figures
 clean_figures:
 	$(CLEAN) $(SRC_FIGURES)
-	cd figures/ 
-	- rm -f $(TGT_FIGURES)
-	- rm -f *.png
+
+.PHONY: proper_figures
+proper_figures: clean_figures
+	$(PROPER) $(SRC_FIGURES)
+	- rm -f figures/*.png
 
 .PHONY: export_figures
 # Requires that you have docker running on your computer.
@@ -47,16 +52,24 @@ tables/%.pdf: tables/table-%.tex
 .PHONY: tables
 tables: $(TGT_TABLES)
 
+.PHONY: mrproper
+mrproper: clean
+	$(PROPER) book.tex
+	- rm -rf release/
+	- rm -rf release_sans_serif/
+	- rm -rf book-epub/
+	- rm -rf book-epub3/
+	- rm -rf book-mobi/
+	- rm -rf book-azw3/
+
 .PHONY: clean
 clean: clean_figures
 	$(CLEAN) book.tex
 	- rm -f book.bbl
 	- rm -f book.run.xml
-	- rm -f book.pdf
 	- rm -f book.mobi
 	- rm -f book.4ct
 	- rm -f book.4tc
-	- rm -f book.dvi
 	- rm -f book.epub
 	- rm -f book.css
 	- rm -f book.idv
@@ -67,18 +80,12 @@ clean: clean_figures
 	- rm -f book*.svg
 	- rm -f book*.html
 	- rm -f book*.xhtml
-	- rm -rf book-epub/
-	- rm -rf book-epub3/
-	- rm -rf book-mobi/
-	- rm -rf book-azw3/
 	- rm -rf book.azw3
 	- rm -f content.opf
 	- find . -name "*.xbb" | xargs rm -f
-	- rm -rf release/
-	- rm -rf release_sans_serif/
 
 .PHONY: release_default
-release_default: clean build_pdf make_release_dir build_ebook
+release_default: mrproper build_pdf make_release_dir build_ebook
 	cp book.pdf release/TheBreadCode-The-Sourdough-Framework.pdf
 	cp book-mobi/book.mobi release/TheBreadCode-The-Sourdough-Framework.mobi
 	cp book-epub/book.epub release/TheBreadCode-The-Sourdough-Framework.epub

--- a/book/makefile
+++ b/book/makefile
@@ -1,8 +1,17 @@
+LATEX := latexmk -cd -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make
+
+%.pdf: %.tex
+	$(LATEX) $<
+
+SRC_FIGURES := $(wildcard figures/fig-*.tex)
+TGT_FIGURES := $(patsubst %.tex,%.pdf, $(SRC_FIGURES))
+
+SRC_TABLES := $(wildcard tables/table-*.tex)
+TGT_TABLES := $(patsubst %.tex,%.pdf, $(SRC_TABLES))
+
 .PHONY: build_pdf
-build_pdf: clean figures tables
-	pdflatex book.tex
-	biber book
-	pdflatex book.tex
+build_pdf: $(TGT_FIGURES) $(TGT_TABLES) book.tex
+	$(LATEX) book.tex
 
 # setup_default_build:
 # 	sed -i '.bak' 's#^\\usepackage{helvet}#%\\usepackage{helvet}#g' book.tex
@@ -24,13 +33,15 @@ clean_figures:
 export_figures:
 	cd figures/ && bash export_figures.sh
 
+# TODO figures/vars.tex is not seen as a dependency
+figures/%.pdf: figures/fig-%.tex
 .PHONY: figures
-figures: clean_figures
-	cd figures && find . -name "fig-*.tex" -exec pdflatex '{}' \;
+figures: $(TGT_FIGURES)
 
+# TODO tables/vars.tex is not seen as a dependency
+tables/%.pdf: tables/table-%.tex
 .PHONY: tables
-tables:
-	cd tables && find . -name "table-*.tex" -exec pdflatex '{}' \;
+tables: $(TGT_TABLES)
 
 .PHONY: clean
 clean: clean_figures

--- a/book/makefile
+++ b/book/makefile
@@ -85,7 +85,7 @@ clean: clean_figures
 	- find . -name "*.xbb" | xargs rm -f
 
 .PHONY: release_default
-release_default: mrproper build_pdf make_release_dir build_ebook
+release_default: build_pdf build_ebook
 	cp book.pdf release/TheBreadCode-The-Sourdough-Framework.pdf
 	cp book-mobi/book.mobi release/TheBreadCode-The-Sourdough-Framework.mobi
 	cp book-epub/book.epub release/TheBreadCode-The-Sourdough-Framework.epub

--- a/book/makefile
+++ b/book/makefile
@@ -1,4 +1,5 @@
 LATEX := latexmk -cd -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make
+CLEAN := latexmk -cd -c
 
 %.pdf: %.tex
 	$(LATEX) $<
@@ -17,16 +18,19 @@ build_pdf: $(TGT_FIGURES) $(TGT_TABLES) book.tex
 # 	sed -i '.bak' 's#^\\usepackage{helvet}#%\\usepackage{helvet}#g' book.tex
 # 	sed -i '.bak' 's#^\\renewcommand{\\familydefault}{\\sfdefault}#%\\renewcommand{\\familydefault}{\\sfdefault}#g' book.tex
 
+.PHONY: clean_tables
+clean_tables:
+	$(CLEAN) $(SRC_TABLES)
+	cd tables/ 
+	- rm -f $(TGT_TABLES)
+	- rm -f *.png
 
 .PHONY: clean_figures
 clean_figures:
-	cd figures
-	rm -rf figures/*.aux
-	rm -rf figures/*.fdb_latexmk
-	rm -rf figures/*.fls
-	rm -rf figures/*.log
-	rm -rf figures/*.pdf
-	rm -rf figures/*.png
+	$(CLEAN) $(SRC_FIGURES)
+	cd figures/ 
+	- rm -f $(TGT_FIGURES)
+	- rm -f *.png
 
 .PHONY: export_figures
 # Requires that you have docker running on your computer.
@@ -45,42 +49,33 @@ tables: $(TGT_TABLES)
 
 .PHONY: clean
 clean: clean_figures
-	rm -f book.blg
-	rm -f book.bbl
-	rm -f book.aux
-	rm -f book.out
-	rm -f book.toc
-	rm -f book.run.xml
-	rm -f book.bcf
-	rm -f book.pdf
-	rm -f book.log
-	rm -f book.mobi
-	rm -f book.4ct
-	rm -f book.4tc
-	rm -f book.dvi
-	rm -f book.epub
-	rm -f book.css
-	rm -f book.fdb_latexmk
-	rm -f book.fls
-	rm -f book.idv
-	rm -f book.lg
-	rm -f book.ncx
-	rm -f book.tmp
-	rm -f book.xref
-	rm -f book*.svg
-	rm -f book*.html
-	rm -f book*.xhtml
-	rm -rf book-epub/
-	rm -rf book-epub3/
-	rm -rf book-mobi/
-	rm -rf book-azw3/
-	rm -rf book.azw3
-	rm -f *.pdf
-	rm -f output.log
-	rm -f content.opf
-	find . -name "*.xbb" | xargs rm -f
-	rm -rf release/
-	rm -rf release_sans_serif/
+	$(CLEAN) book.tex
+	- rm -f book.bbl
+	- rm -f book.run.xml
+	- rm -f book.pdf
+	- rm -f book.mobi
+	- rm -f book.4ct
+	- rm -f book.4tc
+	- rm -f book.dvi
+	- rm -f book.epub
+	- rm -f book.css
+	- rm -f book.idv
+	- rm -f book.lg
+	- rm -f book.ncx
+	- rm -f book.tmp
+	- rm -f book.xref
+	- rm -f book*.svg
+	- rm -f book*.html
+	- rm -f book*.xhtml
+	- rm -rf book-epub/
+	- rm -rf book-epub3/
+	- rm -rf book-mobi/
+	- rm -rf book-azw3/
+	- rm -rf book.azw3
+	- rm -f content.opf
+	- find . -name "*.xbb" | xargs rm -f
+	- rm -rf release/
+	- rm -rf release_sans_serif/
 
 .PHONY: release_default
 release_default: clean build_pdf make_release_dir build_ebook


### PR DESCRIPTION
Uses latexmk that will take care of runnning latex/biber the right amount of time

More automatic/idiomatic rules

Remove forced rebuild 

Runnable in parallel although could be better (I did not look at Sans Serif and ebook could be built in different directories so they can all be built in parallel)