### PR TITLE
Fixed 'typo' in sourdough-starter.tex

### DIFF
--- a/book/sourdough-starter/sourdough-starter.tex
+++ b/book/sourdough-starter/sourdough-starter.tex
@@ -106,7 +106,7 @@ endophytes living in the grain.
 
 Start by measuring approximately 50 grams each of flour and
 water. The measurements don't have to be exact; you can use
-less or more, and just and eyeball the proportions. These
+less or more, or just eyeball the proportions. These
 values are just shown as a reference.
 
 Don't use chlorinated water when setting up your starter.


### PR DESCRIPTION
Fixed a 'typo' or rather a weird sentence. 

"[...] less or more, **and just and** eyeball [...]" -> "[...] less or more, **or just** eyeball [...]" 

Maybe you forgot something to write there although I don't know what.. In the branch "improve-troubleshoothing-wording" this sentence has already been rewritten, but I don't know which branch you'll be using in the end. 

I just wanted to make you aware of this :)
