### PR TITLE
Fix export figures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ book/content.opf
 book/output-epub
 book/figures/*.png
 book/figures/*.pdf
+book/figures/*.in
 book/tables/*.png
 book/tables/*.pdf
 book/release/*
@@ -53,4 +54,5 @@ book/book-azw3/
 book_sans_serif/
 book_serif/
 release_sans_serif/
+epub/
 *.opf

--- a/book/makefile
+++ b/book/makefile
@@ -130,7 +130,7 @@ build_sans_serif_ebook: epub/book_sans_serif.epub epub/book_sans_serif.mobi \
 
 .PHONY: export_figures
 # Requires that you have docker running on your computer.
-export_figures: $(tgt_figures)
+export_figures: build_pdf $(tgt_figures)
 	cd figures/ && bash export_figures.sh
 
 # Goal is not really to have 0 warning reported but we should check we don't


### PR DESCRIPTION
This fixes the `make export_figures` command. See discussion in #119 