### PR TITLE
Remove building sans-serif ebook in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,13 +6,6 @@ jobs:
     steps:
       - name: Set up git repository
         uses: actions/checkout@v3
-      - name: Test building book
-        uses: xu-cheng/texlive-action/full@v1
-        with:
-          run: |
-            apk add make
-            cd book
-            make build_pdf
       - name: Test baking the release versions
         uses: xu-cheng/texlive-action/full@v1
         with:
@@ -22,4 +15,4 @@ jobs:
             tar xzf kindlegen_linux_2.6_i386_v2_9.tar.gz
             mv kindlegen /usr/bin
             cd book
-            make bake
+            make -j build_pdf build_serif_ebook


### PR DESCRIPTION
They are not needed as you can change the font in your reader. Closes: https://github.com/hendricius/the-sourdough-framework/issues/131