### PR TITLE
Use Lualatex

### DIFF
--- a/book/makefile
+++ b/book/makefile
@@ -1,7 +1,7 @@
 # Macros for commands
-LATEX := latexmk -cd -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make
-EBOOK := tex4ebook -d epub -c tex4ebook.cfg
-CLEAN := latexmk -cd -c -use-make
+LATEX := latexmk -cd -pdflua -lualatex="lualatex -interaction=nonstopmode" -use-make
+EBOOK := tex4ebook --lua -d epub -c tex4ebook.cfg
+CLEAN := latexmk --lua -cd -c -use-make
 EBOOK_CONVERT := kindlegen
 CHECK_1 := lacheck
 CHECK_2 := chktex
@@ -225,7 +225,7 @@ release_sans_serif: build_sans_serif_pdf build_sans_serif_ebook | make_release_d
 .PHONY: website
 website:
 	rm -rf $(WEBSITE_DIR)
-	make4ht -c website.cfg -a debug -uf html5+tidy+common_domfilters+dvisvgm_hashes -d $(WEBSITE_DIR) book.tex
+	make4ht --lua -c website.cfg -a debug -uf html5+tidy+common_domfilters+dvisvgm_hashes -d $(WEBSITE_DIR) book.tex
 	cp $(WEBSITE_DIR)/book.html $(WEBSITE_DIR)/index.html
 
 # Debug Stuff from now on
@@ -233,7 +233,7 @@ website:
 show_tools_version:  # Show version of tools used on the build machine
 	- latexmk --version
 	@echo ""
-	- pdflatex --version
+	- lualatex --version
 	@echo ""
 	- tex4ebook --version
 	@echo ""

--- a/book/sourdough.sty
+++ b/book/sourdough.sty
@@ -1,16 +1,15 @@
 \ProvidesPackage{sourdough}
-\usepackage[utf8]{inputenc}
 \usepackage{blindtext}
 \usepackage{graphicx}
 \usepackage{booktabs}
 \usepackage{longtable}
 \usepackage{tocbasic}
-\usepackage[T1]{fontenc}
 \usepackage{chemformula}
 \usepackage{chemfig}
 \usepackage{booktabs}
 \usepackage{makecell}
 \usepackage{siunitx}
+\usepackage{fontspec}
 
 \renewcommand\theadfont{\bfseries}
 
@@ -25,8 +24,7 @@
 
 % Fonts for accessibility
 \ifdefined\isaccessible
-    \usepackage{helvet}
-    \renewcommand{\familydefault}{\sfdefault}
+    \setmainfont{Helvetica}
 \fi
 
 % Kerning in footnotes

--- a/book/sourdough.sty
+++ b/book/sourdough.sty
@@ -24,7 +24,7 @@
 
 % Fonts for accessibility
 \ifdefined\isaccessible
-    \setmainfont{Helvetica}
+    \setmainfont{TeX Gyre Heros} % Helvetica clone
 \fi
 
 % Kerning in footnotes


### PR DESCRIPTION
In order to use open type fonts (OTF) we need to move towards a more modern TeX engine.

@hendricius  I don't have ruby installed yet... so I only have the "raw" ouptut whihc looks fine but if you could test more that would be appreciated, look for weird looking characters, mostly in non-ASCII one like degrees or Umlaut/accents.

Thanks

C