### PR TITLE
Fix dough mass. Should be flour mass.

### DIFF
--- a/book/wheat-sourdough/wheat-sourdough.tex
+++ b/book/wheat-sourdough/wheat-sourdough.tex
@@ -385,8 +385,9 @@ difficulty.
 
 \section{How much starter?}
 
-Most bakers use around \qty{20}{\percent} sourdough starter based on the dough mass.
-I~recommend going much lower, to around 5 to \qty{10}{\percent}.
+Most bakers use around \qty{20}{\percent} sourdough starter based on the
+flour weight.  I~recommend going much lower,
+to around 5 to \qty{10}{\percent}.
 
 By adjusting the amount of pre-ferment you can influence the time your dough
 requires in the bulk fermentation stage. The more starter you use, the faster


### PR DESCRIPTION
For some reason I used dough mass. It should be flour mass. This uses baker's math properly. Fixes #164 