### PR TITLE
Fix flowchart overflow

### DIFF
--- a/book/figures/fig-bulk-fermentation.tex
+++ b/book/figures/fig-bulk-fermentation.tex
@@ -1,14 +1,14 @@
 \begin{tikzpicture}[node distance = 3cm, auto]
   \node [block] (init) {\footnotesize Bulk fermentation};
   \node [block, right of=init] (check_dough) {\footnotesize Check the dough};
-  \node [block, right of=check_dough] (size_increase) {\footnotesize Check dough size increase};
+  \node [block, right of=check_dough, node distance=4cm] (size_increase) {\footnotesize Check dough size increase};
   \node [block, below of=size_increase, node distance=2cm] (ph_value) {\footnotesize Check dough pH value};
   \node [block, below of=ph_value, node distance=2cm] (smell) {\footnotesize Check dough smell};
-  \node [decision, right of=smell] (dough_ready) {\footnotesize Dough ready?};
+  \node [decision, right of=ph_value, node distance=4cm] (dough_ready) {\footnotesize Dough ready?};
   \node [block, below of=dough_ready] (divide_preshape) {\footnotesize Divide and preshape};
   \node [decision, below of=smell] (dough_flattened) {\footnotesize Dough flattened out?};
-  \node [block, left of=dough_flattened] (stretch_fold) {\footnotesize Stretch and fold};
-  \node [block, left of=smell] (wait_60_minutes) {\footnotesize Wait 60~minutes};
+  \node [block, below of=check_dough, node distance=3cm] (wait_60_minutes) {\footnotesize Wait 60~minutes};
+  \node [block, below of=wait_60_minutes, node distance=4cm] (stretch_fold) {\footnotesize Stretch and fold};
 
   \path [line] (init) -- (check_dough);
   \path [line] (check_dough) -- (size_increase);


### PR DESCRIPTION
This fixes a flowchart having text overlapping elements inside of the chart.

**Before:**
<img width="938" alt="Screenshot 2023-08-07 at 21 19 11" src="https://github.com/hendricius/the-sourdough-framework/assets/816859/1f17f592-37d0-4377-83e1-1ef41bc5b89a">

**After:**
<img width="916" alt="Screenshot 2023-08-07 at 21 40 19" src="https://github.com/hendricius/the-sourdough-framework/assets/816859/0e14eb42-ca31-4e00-9d69-9f3a9c268a8b">
