### PR TITLE
Add pdinfo metadata

### DIFF
--- a/book/sourdough.sty
+++ b/book/sourdough.sty
@@ -63,7 +63,18 @@
 \usepackage{bookmark}
 \hypersetup{%
     linktoc=all,
-    allcolors=codeblue
+    allcolors=codeblue,
+    pdfinfo={%
+        Title={The Sourdough Framework},
+        Author={Hendrik Kleinw\"achter},
+        Subject={The sourdough bread baking bible},
+        Keywords={Sourdough, dough, bread, wheat, baking, bake, home-baking,
+            yeast, rye, crumb, debug, gluten, dough strength, crust, DIY,
+            framework, https://the-sourdough-framework.com,
+            https://www.the-bread-code.io/,
+            https://github.com/hendricius/the-sourdough-framework,
+            open-source, CC-BY-SA}
+    }
 }
 
 % Folders where to search for images


### PR DESCRIPTION
Metadata added to the pdf, readable with pdfinfo
Title:           The Sourdough Framework
Subject:         The sourdough bread baking bible
Keywords:        Sourdough, dough, bread, wheat, baking, bake,
    home-baking, yeast, rye, crumb, debug, gluten, dough strength, crust,
    DIY, framework, https://the-sourdough-framework.com,
    https://www.the-bread-code.io/,
    https://github.com/hendricius/the-sourdough-framework, open-source,
    CC-BY-SA
Author:          Hendrik Kleinwächter
Creator:         LaTeX with hyperref
Producer:        LuaTeX-1.16.0
CreationDate:    Sun Aug 27 13:58:19 2023 BST
ModDate:         Sun Aug 27 13:58:19 2023 BST
Custom Metadata: yes
Metadata Stream: no
Tagged:          no
UserProperties:  no
Suspects:        no
Form:            none
JavaScript:      no
Pages:           167
Encrypted:       no
Page size:       595.276 x 841.89 pts (A4)
Page rot:        0
File size:       59180712 bytes
Optimized:       no
PDF version:     1.5