### PR TITLE
Permalinks for website section heads

### DIFF
--- a/book/style.css
+++ b/book/style.css
@@ -62,6 +62,18 @@ main.main-content,main.titlepage,div.footnotes{
   padding:1rem;
 }
 
+.sectionHead a.permalink {
+  opacity: 0.5;
+  text-decoration: none;
+  font-size: 0.75rem;
+  vertical-align: top;
+  line-height: 0.8rem;
+  margin-left: 0.25rem;
+  padding-top: 0.2rem;
+  color: black;
+  display: inline-block;
+}
+
 p.indent, p.noindent{
   text-indent: 0;
   text-align: justify;

--- a/website/assets/script.js
+++ b/website/assets/script.js
@@ -8,4 +8,14 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     }
   });
+
+  // Add permalinks to headers
+  var heads = document.querySelectorAll('.sectionHead');
+  heads.forEach(function (head) {
+      let permalink = document.createElement("a");
+      permalink.href = '#' + head.id;
+      permalink.classList.add('permalink');
+      permalink.append('🔗');
+      head.append(permalink);
+  });
 });

--- a/website/assets/script.js
+++ b/website/assets/script.js
@@ -12,10 +12,10 @@ document.addEventListener('DOMContentLoaded', function() {
   // Add permalinks to headers
   var heads = document.querySelectorAll('.sectionHead');
   heads.forEach(function (head) {
-      let permalink = document.createElement("a");
-      permalink.href = '#' + head.id;
-      permalink.classList.add('permalink');
-      permalink.append('🔗');
-      head.append(permalink);
+    let permalink = document.createElement("a");
+    permalink.href = '#' + head.id;
+    permalink.classList.add('permalink');
+    permalink.append('🔗');
+    head.append(permalink);
   });
 });


### PR DESCRIPTION
This uses vanilla JavaScript to cycle through section headings and add a unicode chain 🔗 link for permalinks to take one directly to it. Mostly this is useful when someone has already been scrolling pretty far and they find what they're looking for and want a link straight to it without scrolling back to the ToC to find it again.

See "Baker's Math" heading in this screenshot:

<img width="1175" alt="image" src="https://github.com/hendricius/the-sourdough-framework/assets/7863437/ebd46075-2f34-4446-a930-9e8ad049090a">
