### PR TITLE
Create anchors in website generator

### DIFF
--- a/website/assets/script.js
+++ b/website/assets/script.js
@@ -8,14 +8,4 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     }
   });
-
-  // Add permalinks to headers
-  var heads = document.querySelectorAll('.sectionHead');
-  heads.forEach(function (head) {
-    let permalink = document.createElement("a");
-    permalink.href = '#' + head.id;
-    permalink.classList.add('permalink');
-    permalink.append('🔗');
-    head.append(permalink);
-  });
 });

--- a/website/modify_build.rb
+++ b/website/modify_build.rb
@@ -58,6 +58,7 @@ class ModifyBuild
     text = add_text_to_coverpage(text, extract_file_from_path(filename))
     text = fix_js_dependency_link(text)
     text = fix_list_of_tables_figures_duplicates(text)
+    text = add_anchors_to_headers(text)
     text = fix_menus_list_figures_tables(text) if is_list_figures_tables?(filename)
     text = fix_list_of_figures_tables_display(text) if is_list_figures_tables?(filename)
     File.open(filename, "w") {|file| file.puts text }
@@ -370,15 +371,17 @@ class ModifyBuild
 
   def mark_menu_as_selected_if_on_page(text, filename)
     doc = build_doc(text)
+    return doc.to_html
+
     selected = doc.css(".menu-items .chapterToc > a").find do |el|
       el["href"] == ""
     end
 
     # Special case for index page
-    if ["index.html", "book.html"].include?(filename)
-      doc.css(".menu-items .chapterToc.home-link")[0].add_class("selected")
-      return doc.to_html
-    end
+    #if ["index.html", "book.html"].include?(filename)
+    #  doc.css(".menu-items .chapterToc.home-link")[0].add_class("selected")
+    #  return doc.to_html
+    #end
 
     # Special case for the flowcharts page which is added by us to the menu.
     # This needs to be done for future manually added pages too
@@ -560,6 +563,20 @@ class ModifyBuild
 
   def build_doc(text)
     Nokogiri::HTML(text)
+  end
+
+  def add_anchors_to_headers(text)
+    doc = build_doc(text)
+    content = doc.css(".sectionHead, .subsectionHead")
+    content.each do |el|
+      anchor = el.attribute("id").value
+      # No anchor for whatever reason
+      next unless anchor
+
+      copy_link = %Q{<a href="##{anchor}" class="permalink">🔗</a>}
+      el.inner_html = "#{el.inner_html}#{copy_link}"
+    end
+    doc.to_html
   end
 end
 


### PR DESCRIPTION
Moves the generation of the hyperlink indicator to the html directly. Followup to #272.

FYI @sha1sum 