### PR TITLE
Fix giberrish website timeline

### DIFF
--- a/book/makefile
+++ b/book/makefile
@@ -1,7 +1,7 @@
 # Macros for commands
 LATEX := latexmk -cd -pdflua -lualatex="lualatex -interaction=nonstopmode" -synctex=1 -use-make
 EBOOK := tex4ebook --lua -d epub -f epub -c tex4ebook.cfg
-WEBSITE := make4ht --lua -c website.cfg -a debug -uf html5+tidy+common_domfilters+dvisvgm_hashes
+WEBSITE := make4ht --lua -c website.cfg -a debug -uf html5+tidy+common_domfilters
 CLEAN := latexmk -cd -lualatex -c -use-make
 CHECK_1 := lacheck
 CHECK_2 := chktex


### PR DESCRIPTION
Solves https://github.com/hendricius/the-sourdough-framework/issues/273 by removing dvisvgm_hashes

Not sure why you had this option to start with ?  Will there be regressions to remove it?

