### PR TITLE
Use trixie as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,20 +15,49 @@ RUN apt-get update && \
     make \
     tidy \
     pandoc \
-    dvisvgm \
     zip \
     git \
     wget \
     ruby3.1 \
     ruby-dev \
     imagemagick \
-    build-essential
+    rsync \
+    wget \
+    perl \
+    xzdec \
+    # dvisvgm dependencies
+    build-essential \
+    fonts-texgyre \
+    fontconfig \
+    libfontconfig1 \
+    libkpathsea-dev \
+    libptexenc-dev \
+    libsynctex-dev \
+    libx11-dev \
+    libxmu-dev \
+    libxaw7-dev \
+    libxt-dev \
+    libxft-dev \
+    libwoff-dev
 
 # Install TeX
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     texlive-full \
     texlive-luatex
+
+# Compile latest dvisvgm
+RUN wget https://github.com/mgieseki/dvisvgm/releases/download/3.1.2/dvisvgm-3.1.2.tar.gz && \
+    mv dvisvgm-3.1.2.tar.gz dvisvgm.tar.gz && \
+    tar -xzf dvisvgm.tar.gz && \
+    cd dvisvgm-* && \
+    ./configure && \
+    make && \
+    make install
+
+# Make sure everything is UTF-8
+RUN echo "export LC_ALL=en_US.UTF-8" >> /root/.bashrc && \
+    echo "export LANG=en_US.UTF-8" >> /root/.bashrc
 
 WORKDIR /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/islandoftex/images/texlive
+FROM debian:trixie
 
 LABEL "maintainer"="Hendrik Kleinwächter <hendrik.kleinwaechter@gmail.com>"
 LABEL "repository"="https://github.com/hendricius/the-sourdough-framework"
@@ -6,7 +6,7 @@ LABEL "homepage"="https://github.com/hendricius/the-sourdough-framework"
 LABEL org.opencontainers.image.source="https://github.com/hendricius/the-sourdough-framework"
 
 # Print release information if needed
-# RUN cat /etc/*release*
+RUN cat /etc/*release*
 
 # Install base depdendencies
 RUN apt-get update && \
@@ -23,6 +23,12 @@ RUN apt-get update && \
     ruby-dev \
     imagemagick \
     build-essential
+
+# Install TeX
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    texlive-full \
+    texlive-luatex
 
 WORKDIR /root
 

--- a/makefile
+++ b/makefile
@@ -13,14 +13,14 @@ build_docker_image:
 push_docker_image: build_docker_image
 	docker push $(DOCKER_IMAGE):latest
 
-# Books/website 
+# Books/website
 
 # Quicker run for each commit, shall catch most problems
 validate:
 	$(DOCKER_CMD) "cd /opt/repo/book && make -j build_serif_pdf build_ebook"
 
 build_pdf:
-	$(DOCKER_CMD)  "cd /opt/repo/book && make"
+	$(DOCKER_CMD) "cd /opt/repo/book && make"
 
 bake:
 	$(DOCKER_CMD) "cd /opt/repo/book && make -j bake"

--- a/website/modify_build.rb
+++ b/website/modify_build.rb
@@ -27,7 +27,7 @@ class ModifyBuild
       html_file_name = fn.split("/")[-1]
       content += "#{HOST}/#{html_file_name}\n"
     end
-    File.open("#{build_dir}/sitemap.txt", 'w') { |file| file.write(content) }
+    File.open("#{build_dir}/sitemap.txt", 'w:UTF-8') { |file| file.write(content) }
   end
 
   def build_latex_html
@@ -41,7 +41,7 @@ class ModifyBuild
   end
 
   def modify_file(filename)
-    orig_text = File.read(filename)
+    orig_text = File.read(filename, encoding: "UTF-8")
     text = fix_double_slashes(orig_text)
     text = fix_navigation_bar(text)
     text = fix_titles(text)
@@ -61,7 +61,7 @@ class ModifyBuild
     text = add_anchors_to_headers(text)
     text = fix_menus_list_figures_tables(text) if is_list_figures_tables?(filename)
     text = fix_list_of_figures_tables_display(text) if is_list_figures_tables?(filename)
-    File.open(filename, "w") {|file| file.puts text }
+    File.open(filename, "w:UTF-8") {|file| file.puts text }
   end
 
   def is_cover_page?(filename)


### PR DESCRIPTION
FYI @cedounet 

```
uname -a
Linux d887876c6f8d 6.3.13-linuxkit #1 SMP PREEMPT Thu Sep  7 07:48:47 UTC 2023 x86_64 GNU/Linux

/bin/bash --version
GNU bash, version 5.2.15(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

latexmk --version
Latexmk, John Collins, 4 Apr. 2023. Version 4.80

lualatex --version
This is LuaHBTeX, Version 1.17.0 (TeX Live 2023)
Development id: 7581

Execute  'luahbtex --credits'  for credits and version details.

There is NO warranty. Redistribution of this software is covered by
the terms of the GNU General Public License, version 2 or (at your option)
any later version. For more information about these matters, see the file
named COPYING and the LuaTeX source.

LuaTeX is Copyright 2022 Taco Hoekwater and the LuaTeX Team.


tex4ebook --version
tex4ebook v0.3j

make4ht --version
make4ht version v0.3m

tidy -version
HTML Tidy for Linux version 5.6.0

dvisvgm --version
dvisvgm 3.0.3

lacheck --version
LaCheck (TeX Live) 1.30
$Id: lacheck.l 63190 2022-04-30 22:15:57Z karl $
License GPLv1+: GNU GPL version 1 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Written by Kresten Krab Thorup and Per Abrahamsen.

chktex --version
ChkTeX v1.7.8 - Copyright 1995-96 Jens T. Berger Thielemann.
Compiled with POSIX extended regex support.

make --version
GNU Make 4.3
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

biber -version
biber version: 2.19

ruby --version
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux-gnu]

convert --version
Version: ImageMagick 6.9.12-98 Q16 x86_64 18038 https://legacy.imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC Modules OpenMP(4.5)
Delegates (built-in): bzlib djvu fftw fontconfig freetype heic jbig jng jp2 jpeg lcms lqr ltdl lzma openexr pangocairo png raw tiff webp wmf x xml zlib

rsync --version
rsync  version 3.2.7  protocol version 31
Copyright (C) 1996-2022 by Andrew Tridgell, Wayne Davison, and others.
Web site: https://rsync.samba.org/
Capabilities:
    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, ACLs,
    xattrs, optional secluded-args, iconv, prealloc, stop-at, no crtimes
Optimizations:
    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
Checksum list:
    xxh128 xxh3 xxh64 (xxhash) md5 md4 sha1 none
Compress list:
    zstd lz4 zlibx zlib none
Daemon auth list:
    sha512 sha256 sha1 md5 md4

rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
are welcome to redistribute it under certain conditions.  See the GNU
General Public Licence for details.
```

Getting some errors when running `make bake now`:

```
[WARNING] domfilter: DOM parsing of listoflocname.html failed:
[WARNING] domfilter: ...ive/2023/texmf-dist/tex/luatex/luaxml/luaxml-mod-xml.lua:175: Unbalanced Tag (/body) [char=16010]

[WARNING] domfilter: DOM parsing of listoflocname.html failed:
[WARNING] domfilter: ...ive/2023/texmf-dist/tex/luatex/luaxml/luaxml-mod-xml.lua:175: Unbalanced Tag (/body) [char=16010]

[WARNING] domfilter: DOM parsing of listtablename.html failed:
[WARNING] domfilter: ...ive/2023/texmf-dist/tex/luatex/luaxml/luaxml-mod-xml.lua:175: Unbalanced Tag (/body) [char=15649]

[WARNING] domfilter: DOM parsing of listtablename.html failed:
[WARNING] domfilter: ...ive/2023/texmf-dist/tex/luatex/luaxml/luaxml-mod-xml.lua:175: Unbalanced Tag (/body) [char=15649]

[WARNING] domfilter: DOM parsing of listfigurename.html failed:
[WARNING] domfilter: ...ive/2023/texmf-dist/tex/luatex/luaxml/luaxml-mod-xml.lua:175: Unbalanced Tag (/body) [char=22455]

[WARNING] domfilter: DOM parsing of listfigurename.html failed:
[WARNING] domfilter: ...ive/2023/texmf-dist/tex/luatex/luaxml/luaxml-mod-xml.lua:175: Unbalanced Tag (/body) [char=22455]

[WARNING] exec_epub: Missing opf file
...023/texmf-dist/scripts/tex4ebook/tex4ebook-exec_epub.lua:341: attempt to index a nil value (local 'f')
make: *** [makefile:93: epub/book.epub] Error 1
```