### PR TITLE
Prevent running validate when pushing on main

### DIFF
--- a/.github/workflows/validate-book-build.yml
+++ b/.github/workflows/validate-book-build.yml
@@ -1,5 +1,11 @@
 name: Validate LaTeX Document
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - '**'  # All branches
+      - '!main' # But main as will do it anyway and more in release_book
+  pull_request:
+
 jobs:
   test_building_book:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Rational is as follow:
    - We ran validate-book on each push on the PR branch anyway
    - We will run release_book which is a superset of validate