### PR TITLE
Upload artifacts on each PR

### DIFF
--- a/.github/workflows/validate-book-build.yml
+++ b/.github/workflows/validate-book-build.yml
@@ -36,3 +36,24 @@ jobs:
           run: |
             cd /app/book
             make -j build_serif_pdf build_ebook
+      - name: Test building website
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/hendricius/the-sourdough-framework:latest
+          options: -v ${{ github.workspace }}:/app
+          run: |
+            cd /app/book
+            make -j website
+      - name: Upload book Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: books
+          path: |
+            book/book_serif/book.log
+            book/book_serif/book.pdf
+            book/book-epub/book.epub
+      - name: Upload website Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: website
+          path: website/static_website_html

--- a/.github/workflows/validate-book-build.yml
+++ b/.github/workflows/validate-book-build.yml
@@ -45,7 +45,7 @@ jobs:
             cd /app/book
             make -j website
       - name: Upload book Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: books
           path: |
@@ -53,7 +53,7 @@ jobs:
             book/book_serif/book.pdf
             book/book-epub/book.epub
       - name: Upload website Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: website
           path: website/static_website_html

--- a/makefile
+++ b/makefile
@@ -14,10 +14,11 @@ push_docker_image: build_docker_image
 	docker push $(DOCKER_IMAGE):latest
 
 # Books/website
+build_serif_pdf:
+	$(DOCKER_CMD) "cd /opt/repo/book && make build_serif_pdf"
 
-# Quicker run for each commit, shall catch most problems
-validate:
-	$(DOCKER_CMD) "cd /opt/repo/book && make -j build_serif_pdf build_ebook"
+build_ebook:
+	$(DOCKER_CMD) "cd /opt/repo/book && make build_ebook"
 
 build_pdf:
 	$(DOCKER_CMD) "cd /opt/repo/book && make"


### PR DESCRIPTION
This will store the built book on every pull request and attach it to the workflow:

<img width="1429" alt="image" src="https://github.com/hendricius/the-sourdough-framework/assets/816859/b32db297-a89d-49bd-a8ad-5327d9f261cd">

This way we can always see the preview of what we are about to merge before actually merging. Downside - it adds a bit of build time to upload everything.