### PR TITLE
Small changes to Docker command and `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.xbb
 *.aux
 *.fdb_latexmk

--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ DOCKER_CMD := docker run -it -v $(PWD):/opt/repo --platform linux/x86_64 $(DOCKE
 
 # Dockers targets
 build_docker_image:
-	docker build -t $(DOCKER_IMAGE) -f Dockerfile --progress=plain .
+	docker build -t $(DOCKER_IMAGE) -f Dockerfile --progress=plain --rm .
 
 push_docker_image: build_docker_image
 	docker push $(DOCKER_IMAGE):latest

--- a/makefile
+++ b/makefile
@@ -1,14 +1,14 @@
 .DEFAULT_GOAL := build_pdf
 
 DOCKER_IMAGE := ghcr.io/hendricius/the-sourdough-framework
-DOCKER_CMD := docker run -it -v $(PWD):/opt/repo --platform linux/x86_64 $(DOCKER_IMAGE) /bin/bash -c
+DOCKER_CMD := docker run --rm -it -v $(PWD):/opt/repo --platform linux/x86_64 $(DOCKER_IMAGE) /bin/bash -c
 
 .PHONY: bake build_pdf build_docker_image push_docker_image validate website
 .PHONY: print_os_version start_shell printvars show_tools_version mrproper
 
 # Dockers targets
 build_docker_image:
-	docker build -t $(DOCKER_IMAGE) -f Dockerfile --progress=plain --rm .
+	docker build -t $(DOCKER_IMAGE) -f Dockerfile --progress=plain .
 
 push_docker_image: build_docker_image
 	docker push $(DOCKER_IMAGE):latest


### PR DESCRIPTION
- Adds `.DS_Store` to `.gitignore` for Mac users.
- Adds `--rm` option flag to `docker` command so that containers are removed when the process is finished rather than leaving a bunch of containers around.