### PR TITLE
#308 — Build docker image for both amd64 and arm64

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.determine_tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -49,8 +49,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
           platforms: linux/amd64,linux/arm64
+          push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.determine_tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN cat /etc/*release*
 
 # Install base depdendencies
 RUN apt-get update && \
-    apt-get install --yes -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes -y --no-install-recommends \
     sudo \
     make \
     tidy \
@@ -42,7 +42,7 @@ RUN apt-get update && \
 
 # Install TeX
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     texlive-full \
     texlive-luatex
 

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := build_pdf
 
 DOCKER_IMAGE := ghcr.io/hendricius/the-sourdough-framework
-DOCKER_CMD := docker run -it -v $(PWD):/opt/repo --platform linux/x86_64 $(DOCKER_IMAGE) /bin/bash -c
+DOCKER_CMD := docker run -it -v $(PWD):/opt/repo $(DOCKER_IMAGE) /bin/bash -c
 
 .PHONY: bake build_pdf build_docker_image push_docker_image validate website
 .PHONY: print_os_version start_shell printvars show_tools_version mrproper


### PR DESCRIPTION
Builds the Docker image in both `arm64` and `amd64` architectures, which will add the ability for Mac M1/M2/M3 users to run the container without emulation.

Fixes #308 