### PR TITLE
Prevent tex4ht to load enumitem

### DIFF
--- a/book/sourdough.sty
+++ b/book/sourdough.sty
@@ -10,13 +10,12 @@
 \usepackage[mode=match, reset-text-family=false]{siunitx}
 \usepackage{fontspec}
 \usepackage{calc}
-\usepackage{enumitem}
 \usepackage[font={sffamily, sbseries}]{quoting}
-\usepackage{enumitem}
 \usepackage{microtype}
 
 % style=nextline breaks on make4ht
 \ifdefined\HCode\else
+\usepackage{enumitem}
 \setlist[description]{style=nextline, leftmargin=0cm}
 \fi
 


### PR DESCRIPTION
Apparently it breaks on kobo e-reader, see https://github.com/hendricius/the-sourdough-framework/issues/306