### PR TITLE
Revert "#308 — Build docker image for both amd64 and arm64 (#311)"

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -49,7 +49,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.determine_tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN cat /etc/*release*
 
 # Install base depdendencies
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes -y --no-install-recommends \
+    apt-get install --yes -y --no-install-recommends \
     sudo \
     make \
     tidy \
@@ -42,7 +42,7 @@ RUN apt-get update && \
 
 # Install TeX
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    apt-get install -y --no-install-recommends \
     texlive-full \
     texlive-luatex
 

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := build_pdf
 
 DOCKER_IMAGE := ghcr.io/hendricius/the-sourdough-framework
-DOCKER_CMD := docker run -it -v $(PWD):/opt/repo $(DOCKER_IMAGE) /bin/bash -c
+DOCKER_CMD := docker run -it -v $(PWD):/opt/repo --platform linux/x86_64 $(DOCKER_IMAGE) /bin/bash -c
 
 .PHONY: bake build_pdf build_docker_image push_docker_image validate website
 .PHONY: print_os_version start_shell printvars show_tools_version mrproper


### PR DESCRIPTION
This reverts commit e6709b0f5e363b526b3698c8de05effbfb22f3ea.

https://github.com/actions/runner-images/issues/5631

<img width="2253" alt="image" src="https://github.com/hendricius/the-sourdough-framework/assets/816859/73166dfc-9d1d-4841-8532-4da96e7d3810">

It seems like there is no proper arm64 support yet. So we need to live with the slightly lower image for MacOS now 😎 .

FYI @sha1sum 