### PR TITLE
In free standing bread section: prevent reference from bleeding into the margin

### DIFF
--- a/book/bread-types/bread-types.tex
+++ b/book/bread-types/bread-types.tex
@@ -402,5 +402,5 @@ performed perfectly, without mistakes.
 But after baking you will be rewarded with a beautiful bread
 with great taste and consistency.
 
-There is a full, dedicated recipe and tutorial
-for this type of bread in the~''\nameref{chapter:wheat-sourdough}''~Chapter.
+There is a dedicated recipe and tutorial for this type of bread in the
+``\nameref{chapter:wheat-sourdough}'' chapter.


### PR DESCRIPTION
Since I had to create a fork for the other PR, already I thought, why not contribute some minor LaTeX cosmetics, as well...

Because the namedref to the "Wheat sourdough" chapter is not broken up on space, it bleeds into the margin.

Also: fix quotation marks and capitalization of "chapter".