### PR TITLE
Fix flowchart border on website

### DIFF
--- a/book/style.css
+++ b/book/style.css
@@ -480,6 +480,10 @@ nav.TOC span:hover, nav.TOC span:hover *, nav.TOC span.chapterToc.selected, nav.
 p.flowchart-image-wrapper {
   background: white;
   padding: 20px;
+  border-radius: var(--border-radius);
+  border: 2px solid var(--c-black);
+  display: flex;
+  justify-content: center;
 }
 
 .menu-items .menu-group:last-of-type .menu-arrow {

--- a/website/modify_build.rb
+++ b/website/modify_build.rb
@@ -629,7 +629,9 @@ class ModifyBuild
        to everyone, I have decided to make it available as a free digital download.
     </p>
 
-    <img alt="One of my best Sourdough Breads" class="home-bread" src="bread.jpg" />
+    <a href="bread.jpg">
+      <img alt="One of my best Sourdough Breads" class="home-bread" src="bread.jpg" />
+    </a>
 
     <p class="noindent">
       However, producing and maintaining resources like this requires


### PR DESCRIPTION
Good job spotting this. This fixes #345.

<img width="899" alt="image" src="https://github.com/hendricius/the-sourdough-framework/assets/816859/a5e4b51e-c777-49cd-adee-291e6e629094">

They are also centered now in the white container.