### PR TITLE
Temperature of the dough in the oven and its effects

### DIFF
--- a/book/baking/baking.tex
+++ b/book/baking/baking.tex
@@ -38,24 +38,24 @@ At  \qty{75}{\degreeCelsius} (\qty{167}{\degF}) the surface of your dough turns 
 holds together nicely but is still extensible. This gel is essential
 for oven spring as it retains the gas inside your dough.
 
-At around  \qty{100}{\degreeCelsius} (\qty{212}{\degF}) the water starts to evaporate out of your
-dough. If this weren't the case, your dough would taste soggy and
-doughy. The higher hydration your dough has, the more water your bread
+As the dough warms up in the oven, the water starts to evaporate out of your
+dough. If this weren't the case, your bread would come out soggy and
+doughy. The higher the hydration of your dough, the more water your bread
 still contains after the bake, changing its consistency.  As a result the
-crumb is going to taste a bit more moist.
+crumb will be somewhat moister.
 
-Another often undervalued step is the evaporation of acids.
+Another often undervalued step is the evaporation of acids from the crust.
 At~\qty{118}{\degreeCelsius} (\qty{244}{\degF}) the acetic acid in your dough
 starts to evaporate.
 Shortly after at~\qty{122}{\degreeCelsius} (\qty{252}{\degF}) the lactic acid begins evaporating.
 This is crucial to understand and it opens the door to many interesting
 ways to influence your final bread's taste. As more and more water
-begins to evaporate the acids in your dough become more concentrated.
-There is less water but in relation you have more acids, therefore a shorter
+evaporates the acids in your dough become more concentrated.
+There is less water but in relation you have more acids, therefore a longer
 bake will lead to a more tangy dough. The longer you bake the bread,
 the more of the water evaporates, but also ultimately the acids will follow.
 The longer you bake, the less sour your bread is going to be. By controlling
-baking time you can influence which sourness level you would like to achieve.
+baking time you can somewhat influence which sourness level you would like to achieve. Since the inside of the bread will never go above \qty{100}{\degreeCelsius} (\qty{212}{\degF}), acids cannot evaporate from there.
 
 It would be a very interesting experiment to bake a bread at different exact
 temperatures. How would a bread taste with only evaporated water but


### PR DESCRIPTION
Evaporation happens at room temperature, too - therefore we cover doughs that rest before baking. 
The inside of a loaf does not reach temps above 100 °C - unless you seriously overbake until you end up with a brick instead of a loaf.