### PR TITLE
Remove parallel option from make

### DIFF
--- a/.github/workflows/release-book-website.yml
+++ b/.github/workflows/release-book-website.yml
@@ -64,7 +64,7 @@ jobs:
           options: -v ${{ github.workspace }}:/app
           run: |
             cd /app/book
-            make -j bake
+            make bake
       - name: Release baked book to S3
         uses: shallwefootball/s3-upload-action@master
         with:

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ build_pdf:
 	$(DOCKER_CMD) "cd /opt/repo/book && make"
 
 bake:
-	$(DOCKER_CMD) "cd /opt/repo/book && make -j bake"
+	$(DOCKER_CMD) "cd /opt/repo/book && make bake"
 
 website:
 	$(DOCKER_CMD) "cd /opt/repo/book && make website"


### PR DESCRIPTION
This temporarily removes the parallel option from make to ensure that we can release the booklet. I am not sure why it causes an issue. Baking the book without it causes no problem.

I also recommend that we use the `bake` option for the testing workflow in the future. This increases build time but makes sure we don't merge something that might now work.