### PR TITLE
Remove redundant aliquot statement

### DIFF
--- a/book/wheat-sourdough/wheat-sourdough.tex
+++ b/book/wheat-sourdough/wheat-sourdough.tex
@@ -792,8 +792,7 @@ My go-to method for beginners is to use an \emph{Aliquot jar}.
 The aliquot is a sample that you extract from your dough. The
 sample is extracted after creating the initial dough strength.
 You monitor the aliquot's size increase to judge the
-level of fermentation of your main dough. The aliquot
-sample is extracted after creating dough strength. As your
+level of fermentation of your main dough. As your
 dough ferments, so does the content of your aliquot jar. The moment your
 sample reached a certain size, your main dough is ready
 to be shaped and proofed. The size increase you should


### PR DESCRIPTION
Tidied up some duplication in the section on aliquot where similar statements were made in the same paragraph.

> The sample is extracted after creating the initial dough strength.

> The aliquot sample is extracted after creating dough strength.