### PR TITLE
Allow URL to break

### DIFF
--- a/book/sourdough.sty
+++ b/book/sourdough.sty
@@ -75,10 +75,11 @@
 \addbibresource{references.bib}
 
 % Clickable links in the table of contents
-\usepackage[ocgcolorlinks]{hyperref}
+\usepackage{hyperref}
 \usepackage{bookmark}
 \hypersetup{%
     linktoc=all,
+    colorlinks = true,
     linkcolor = hlorange,
     urlcolor  = codeblue,
     citecolor = hlocre,


### PR DESCRIPTION
This was prevented by ocgcolorlinks which was here to have links printed in black but looking like colors in the pdf on screen... as Doc hyperref explains:

• Main disadvantage: Links cannot be broken across lines. PDF reference
1.7: 4.10.2 “Making