### PR TITLE
epub - change to lower res file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ book/book-epub/
 book/bw-book-epub/*
 book/release/*
 book/low-res-book-epub/*
+book/epub_build/*
+book/website_build/*

--- a/book/makefile
+++ b/book/makefile
@@ -13,6 +13,7 @@ REDUCE_PIC_COLOR := -quality 80\%
 RSYNC := rsync -au --exclude 'book.epub' --exclude '*.jpg'
 GIT := git --no-pager
 SPELL_CHECK := hunspell -t -l -d en_US
+EPUBSIZE := `du -sb epub/low_res_book.epub | cut -f1`
 
 # We want bash as shell
 SHELL := $(shell if [ -x "$$BASH" ]; then echo $$BASH; \
@@ -294,7 +295,7 @@ mrproper: clean
 # top level releases rules
 .PHONY: bake release_serif release_sans_serif
 
-bake: release_serif release_sans_serif release_booklet website
+bake: release_serif enforceepubsize release_sans_serif release_booklet website
 
 release:
 	mkdir -p release
@@ -387,3 +388,11 @@ printvars:  # Print all variables in the makefile
 	@$(foreach V,$(sort $(.VARIABLES)), \
 	$(if $(filter-out environ% default automatic, \
 	$(origin $V)),$(info $V=$($V) ($(value $V)))))
+
+.PHONY: enforceepubsize
+
+enforceepubsize: 
+	@if [ $(EPUBSIZE) -gt 50000000 ]; then \
+		echo "ERROR: epub File too big"; \
+		exit 1; \
+	fi

--- a/book/makefile
+++ b/book/makefile
@@ -11,6 +11,7 @@ REDUCE_PIC := -resize '800x800>' \
 	    -set colorspace Gray -separate -evaluate-sequence Mean
 REDUCE_PIC_COLOR := -quality 80\%
 RSYNC := rsync -au --exclude 'book.epub' --exclude '*.jpg' --exclude '*.png'
+RSYNC_INC_PNG := rsync -au --exclude 'book.epub' --exclude '*.jpg'
 GIT := git --no-pager
 SPELL_CHECK := hunspell -t -l -d en_US
 
@@ -109,7 +110,7 @@ book_serif/book.pdf: $(src_all)
 book_sans_serif/book_sans_serif.pdf: $(src_all)
 	$(LATEX) -output-directory=book_sans_serif book_sans_serif.tex
 
-.PHONY: copy_ebook_files copy_ebook_files_cl
+.PHONY: copy_ebook_files copy_ebook_files_low_res
 
 epub/%.epub: %.tex $(ebook_src) cover/cover-page.xbb
 	$(EBOOK) $<
@@ -117,8 +118,8 @@ epub/%.epub: %.tex $(ebook_src) cover/cover-page.xbb
 copy_ebook_files: build_ebook
 	$(RSYNC) epub_build/book-epub/ bw-book-epub/
 
-copy_ebook_files_cl: build_ebook
-	$(RSYNC) epub_build/book-epub/ low-res-book-epub/
+copy_ebook_files_low_res: build_ebook
+	$(RSYNC_INC_PNG) epub_build/book-epub/ low-res-book-epub/
 
 # We do not convert SVG to B&W or lower res for now as they are super small
 # anyway
@@ -134,15 +135,11 @@ low-res-book-epub/OEBPS/%.jpg: %.jpg
 	mkdir -p $(dir $@)
 	$(CONVERT_PIC) $< $(REDUCE_PIC_COLOR) $@
 
-low-res-book-epub/OEBPS/%.png: %.png
-	mkdir -p $(dir $@)
-	$(CONVERT_PIC) $< $(REDUCE_PIC_COLOR) $@
-
 epub/bw_book.epub: copy_ebook_files $(bw_images)
 	cd bw-book-epub; zip -q0X ../epub/bw_book.epub mimetype
 	cd bw-book-epub; zip -q9XrD ../epub/bw_book.epub ./
 
-epub/low_res_book.epub: copy_ebook_files_cl $(low_res_images)
+epub/low_res_book.epub: copy_ebook_files_low_res $(low_res_images)
 	cd low-res-book-epub; zip -q0X ../epub/low_res_book.epub mimetype
 	cd low-res-book-epub; zip -q9XrD ../epub/low_res_book.epub ./
 
@@ -303,9 +300,8 @@ release:
 
 release_serif: build_serif_pdf build_ebook build_bw_ebook build_low_res_ebook | release
 	cp book_serif/book.pdf release/TheBreadCode-The-Sourdough-Framework.pdf
-	cp epub/book.epub release/TheBreadCode-The-Sourdough-Framework.epub
 	cp epub/bw_book.epub release/TheBreadCode-The-Sourdough-Framework-black-and-white.epub
-	cp epub/low_res_book.epub release/TheBreadCode-The-Sourdough-Framework-reduced-size.epub
+	cp epub/low_res_book.epub release/TheBreadCode-The-Sourdough-Framework.epub
 
 release_sans_serif: build_sans_serif_pdf | release
 	cp book_sans_serif/book_sans_serif.pdf  release/TheBreadCode-The-Sourdough-Framework-sans-serif.pdf

--- a/book/makefile
+++ b/book/makefile
@@ -295,7 +295,7 @@ mrproper: clean
 # top level releases rules
 .PHONY: bake release_serif release_sans_serif
 
-bake: release_serif enforceepubsize release_sans_serif release_booklet website
+bake: release_serif release_sans_serif release_booklet website
 
 release:
 	mkdir -p release
@@ -304,6 +304,10 @@ release_serif: build_serif_pdf build_ebook build_bw_ebook build_low_res_ebook | 
 	cp book_serif/book.pdf release/TheBreadCode-The-Sourdough-Framework.pdf
 	cp epub/bw_book.epub release/TheBreadCode-The-Sourdough-Framework-black-and-white.epub
 	cp epub/low_res_book.epub release/TheBreadCode-The-Sourdough-Framework.epub
+	@if [ $(EPUBSIZE) -gt 49500000 ]; then \
+		echo "ERROR: epub File too big"; \
+		exit 1; \
+	fi	
 
 release_sans_serif: build_sans_serif_pdf | release
 	cp book_sans_serif/book_sans_serif.pdf  release/TheBreadCode-The-Sourdough-Framework-sans-serif.pdf
@@ -388,11 +392,3 @@ printvars:  # Print all variables in the makefile
 	@$(foreach V,$(sort $(.VARIABLES)), \
 	$(if $(filter-out environ% default automatic, \
 	$(origin $V)),$(info $V=$($V) ($(value $V)))))
-
-.PHONY: enforceepubsize
-
-enforceepubsize: 
-	@if [ $(EPUBSIZE) -gt 50000000 ]; then \
-		echo "ERROR: epub File too big"; \
-		exit 1; \
-	fi

--- a/book/makefile
+++ b/book/makefile
@@ -10,8 +10,7 @@ REDUCE_PIC := -resize '800x800>' \
 	    -strip -interlace Plane  -gaussian-blur 0.05 -quality 85\% \
 	    -set colorspace Gray -separate -evaluate-sequence Mean
 REDUCE_PIC_COLOR := -quality 80\%
-RSYNC := rsync -au --exclude 'book.epub' --exclude '*.jpg' --exclude '*.png'
-RSYNC_INC_PNG := rsync -au --exclude 'book.epub' --exclude '*.jpg'
+RSYNC := rsync -au --exclude 'book.epub' --exclude '*.jpg'
 GIT := git --no-pager
 SPELL_CHECK := hunspell -t -l -d en_US
 
@@ -116,10 +115,10 @@ epub/%.epub: %.tex $(ebook_src) cover/cover-page.xbb
 	$(EBOOK) $<
 
 copy_ebook_files: build_ebook
-	$(RSYNC) epub_build/book-epub/ bw-book-epub/
+	$(RSYNC) --exclude '*.png' epub_build/book-epub/ bw-book-epub/
 
 copy_ebook_files_low_res: build_ebook
-	$(RSYNC_INC_PNG) epub_build/book-epub/ low-res-book-epub/
+	$(RSYNC) epub_build/book-epub/ low-res-book-epub/
 
 # We do not convert SVG to B&W or lower res for now as they are super small
 # anyway


### PR DESCRIPTION
@cedounet This is the first two parts of the discussion on the [issue with keeping the epub size below 50 MB](https://github.com/hendricius/the-sourdough-framework/issues/401#issuecomment-2565432172) 

 A few points that I am struggling with:
- when I do a `make mrproper`, I have to `make bake` twice in order to complete the build. I'm not sure if my changes are causing this issue or not. 
- I was trying to determine a way to go directly to the condensed images, but I am unsure of a way to do that (maybe the current way is best).
- `epub_build` folder does not appear to be in .gitignore. I was not sure if there was a reason for this. 
- I can check the file size (using something simple like `$(du -sb $filename | cut -f1)`, but should the test error out on > 50MB? 