### PR TITLE
Rearranged starter process flowchart and added sidebar

### DIFF
--- a/book/figures/fig-starter-process.tex
+++ b/book/figures/fig-starter-process.tex
@@ -1,19 +1,28 @@
 \begin{tikzpicture}[node distance = 3.5cm, auto]
-  \node [start] (init) {Mix \qty{50}{\gram} flour + \qty{50}{\gram} water, stir};
-  \node [block, right of=init] (wait2) {Wait\\ \qty{24}{\hour}};
-  \path [line] (init) -- (wait2);
-  \node [block, below of=wait2, node distance=3.5cm] (feed) {\qty{10}{\gram} of previous day + \qty{50}{\gram} water + \qty{50}{\gram} flour, stir};
-  \path [line] (wait2) -- (feed);
-  \node [block, below of=feed] (discard) {Discard the rest};
-  \path [line] (feed) -- (discard);
-  \node [decision, right of=feed, node distance=3.5cm] (decide) {Is good?};
-  \node [decision, above of=decide, node distance=3.5cm] (timeout) {Less than 10 feeds?};
-  \node [fail, right of=timeout, node distance=3.5cm] (discard2) {Batch failed};
-  \path [line] (timeout) -- node{no} (discard2);
-  \path [line] (timeout) -- node{yes} (wait2);
-  \path [line] (feed) -- (decide);
-  \node [success, right of=decide, node distance=3.5cm] (use) {Ready to use};
-  \path [line] (decide) -- node{no} (timeout);
-  \path [line] (wait2) -- (feed);
-  \path [line] (decide) -- node{yes} (use);
+
+  \node [start] (start) { Start with Initial Mixture };
+  \node [block, right of=start, node distance = 3.2cm] (wait) { Wait\\ \qty{24}{\hour} };
+  \node [decision, right of=wait, node distance = 3.2cm] (readycheck) { Ready? };
+  \node [block, below of=wait, node distance = 3cm] (feed) { Feed the Mixture };
+  \node [decision, right of=feed, node distance = 3.2cm] (limitcheck) { Failed? };
+  \node [fail, right of=limitcheck, node distance = 3.2cm] (abort) { Discard All, Start Over };
+  \node [success, right of=readycheck, node distance = 3.2cm] (final) { Done };
+
+  \draw [thick, -{Latex}] (start) -- (wait);
+  \draw [thick, -{Latex}] (wait) -- (readycheck);
+  \draw [thick, -{Latex}] (feed) -- (wait);
+  \draw [thick, -{Latex}] (readycheck) -- node { No } (limitcheck);
+  \draw [thick, -{Latex}] (limitcheck) -- node (feedok) { No } (feed) ;
+  \draw [thick, -{Latex}] (limitcheck) -- node { Yes } (abort);
+  \draw [thick, -{Latex}] (readycheck) -- node { Yes } (final);
+
+  \node [below of=feedok, node distance=2.5cm] (details1) [shape=rectangle,draw,fill=white!90!black]{
+        \begin{tabular}{c}
+	    \fontsize{7}{9}\selectfont For the \emph{Initial Mixture}, mix \qty{50}{\gram} flour/\qty{50}{\gram} water. \\
+            \fontsize{7}{9}\selectfont The Mixture is \emph{Ready} when it has \emph{grown}, has \emph{bubbles}, and \emph{smells} vinegary/yoghurty. \\
+            \fontsize{7}{9}\selectfont The Mixture has \emph{Failed} when you have fed it too many (eg 10) times without success. \\
+	    \fontsize{7}{9}\selectfont To \emph{Feed the Mixture}, discard all but \qty{10}{\gram}, mix in \qty{50}{\gram} flour and \qty{50}{\gram} water.
+        \end{tabular}
+  
+  };
 \end{tikzpicture}

--- a/book/figures/flowcharts_tikz.tex
+++ b/book/figures/flowcharts_tikz.tex
@@ -1,6 +1,6 @@
 \tikzstyle{every picture}+=[font=\footnotesize\sffamily]
 \usetikzlibrary{calc, shapes, arrows, decorations.pathreplacing, calligraphy,
-                positioning}
+                positioning, arrows.meta}
 \tikzstyle{decision} = [diamond, draw=codeblack, fill=codeblack, text=white,
     text width=4.5em, text badly centered, node distance=3cm, inner sep=0pt,
     line width=2mm]


### PR DESCRIPTION
- Rearranged to make sure ready check comes before feeding.
- Simplified by removing Discard block, and shortening block titles.
- Details moved to legend box below.
- Changed arrowheads to be cleaner "Latex" style.