### PR TITLE
Update all flowchart arrows to "Latex" arrows

### DIFF
--- a/book/figures/fig-starter-process.tex
+++ b/book/figures/fig-starter-process.tex
@@ -25,43 +25,23 @@
   \node [fail, right of=limitcheck_n, node distance = 3.2cm] (abort_n) { Discard All, Start Over };
   \node [success, right of=readycheck_n, node distance = 3.2cm] (final_n) { Done };
 
-  \draw [thick, -{Latex}] (start_n) -- (wait_n);
-  \draw [thick, -{Latex}] (wait_n) -- (readycheck_n);
-  \draw [thick, -{Latex}] (feed_n) -- (wait_n);
-  \draw [thick, -{Latex}] (readycheck_n) -- node { No } (limitcheck_n);
-  \draw [thick, -{Latex}] (limitcheck_n) -- node (feedok_n) { No } (feed_n) ;
-  \draw [thick, -{Latex}] (limitcheck_n) -- node { Yes } (abort_n);
-  \draw [thick, -{Latex}] (readycheck_n) -- node { Yes } (final_n);
+  \draw [line] (start_n) -- (wait_n);
+  \draw [line] (wait_n) -- (readycheck_n);
+  \draw [line] (feed_n) -- (wait_n);
+  \draw [line] (readycheck_n) -- node { No } (limitcheck_n);
+  \draw [line] (limitcheck_n) -- node (feedok_n) { No } (feed_n) ;
+  \draw [line] (limitcheck_n) -- node { Yes } (abort_n);
+  \draw [line] (readycheck_n) -- node { Yes } (final_n);
 
-  \node [below of=feedok_n, node distance=4.5cm] (details1) [shape=rectangle,draw,fill=white!90!black]{
-        \begin{tabular}{l}
-	    \fontsize{7}{9}\selectfont For the \emph{Initial Mixture}, mix \qty{50}{\gram} flour/\qty{50}{\gram} water. \\
-            \fontsize{7}{9}\selectfont The Mixture is \emph{Ready} when it has \emph{grown}, has \emph{bubbles}, and \emph{smells} vinegary/yoghurty. \\
-            \fontsize{7}{9}\selectfont The Mixture has \emph{Failed} when you have fed it too many (eg 10) times without success. \\
-	    \fontsize{7}{9}\selectfont To \emph{Feed the Mixture}, discard all but \qty{10}{\gram}, mix in \qty{50}{\gram} flour and \qty{50}{\gram} water.
-        \end{tabular}
-    };
+  \node [below of=feedok_n, node distance=2cm, align=left] (details2) [shape=rectangle,draw,fill=white!90!black]{
+    \fontsize{7}{9}\selectfont For the \emph{Initial Mixture}, mix \qty{50}{\gram} flour/\qty{50}{\gram} water.\\
+    \fontsize{7}{9}\selectfont The Mixture is \emph{Ready} when it has
+    \emph{grown}, has \emph{bubbles}, and \emph{smells}
+    vinegary/yoghurty. \\
 
-%  Feel free to comment out and see how it looks similar to above
-%  \node [below of=details1, node distance=1.5cm, align=left] (details2) [shape=rectangle,draw,fill=white!90!black]{
-%	    \fontsize{7}{9}\selectfont For the \emph{Initial Mixture}, mix
-%        \qty{50}{\gram} flour/\qty{50}{\gram} water.\\
-%            \fontsize{7}{9}\selectfont The Mixture is \emph{Ready} when it has
-%            \emph{grown}, has \emph{bubbles}, and \emph{smells}
-%            vinegary/yoghurty. \\
-%
-%            \fontsize{7}{9}\selectfont The Mixture has \emph{Failed} when you
-%            have fed it too many (eg 10) times without success.\\
-%
-%	    \fontsize{7}{9}\selectfont To \emph{Feed the Mixture}, discard all but \qty{10}{\gram}, mix in \qty{50}{\gram} flour and \qty{50}{\gram} water.
-%  };
+    \fontsize{7}{9}\selectfont The Mixture has \emph{Failed} when you
+    have fed it too many (eg 10) times without success.\\
 
-  \node [below of=details1, node distance=2.5cm] (detailsced) [shape=rectangle,draw,fill=white!90!black]{
-      \begin{tabular}{@{}ll@{}}
-          \textbf{Initial Mixture}:& Mix \qty{50}{\gram} flour/\qty{50}{\gram} water. \\
-          \textbf{Feed the Mixture}:& Discard all but \qty{10}{\gram}, mix in \qty{50}{\gram} flour and \qty{50}{\gram} water\\
-          \textbf{Ready}:& The mixture has \emph{grown}, has \emph{bubbles}, and \emph{smells} vinegary/yoghurty. \\
-          \textbf{Failed}: & The mixture has been fed too many (eg 10) times without success. \\
-        \end{tabular}
-    };
+    \fontsize{7}{9}\selectfont To \emph{Feed the Mixture}, discard all but \qty{10}{\gram}, mix in \qty{50}{\gram} flour and \qty{50}{\gram} water.
+  };
 \end{tikzpicture}

--- a/book/figures/fig-stiff-starter-conversion.tex
+++ b/book/figures/fig-stiff-starter-conversion.tex
@@ -11,7 +11,7 @@
   \path [line] (init) -- (feed_new_ratio);
   \path [line] (feed_again) -- (feed_new_ratio);
   \path [line] (next_day) -- (ready_signs);
-  \path [line] (ready_signs) -- node{no} (feed_again |- last_feed) |- (feed_again.south);
+  \path [line] (ready_signs) -- node{no} (feed_again |- last_feed) -| (feed_again.south);
   \path [line] (ready_signs) -- node{yes} (last_feed);
   \path [line] (last_feed) -- node{after \qtyrange{6}{12}{\hour}} (bread_dough);
   \path [line] (feed_new_ratio) -- (too_dry);

--- a/book/figures/flowcharts_tikz.tex
+++ b/book/figures/flowcharts_tikz.tex
@@ -19,7 +19,8 @@
 \tikzstyle{fail} = [rectangle, draw=codeblack, fill=redpic,  text=black,
     text width=5em, text centered, rounded corners, minimum height=4em,
     line width=0.4mm]
-\tikzstyle{line} = [draw, -latex', thick, ->,>=to]
+% The arrowed connector line between nodes
+\tikzstyle{line} = [draw, thick, ->, >={Latex}]
 
 \tikzstyle{BC} =  [decorate,  % Brace Calligraphic
                  decoration={calligraphic brace, amplitude=3mm, raise=1mm},


### PR DESCRIPTION
- Change tikzstyle definition for "line" so that all flowchart arrows have the "Latex" styling.
- Fix the little line that the above change introduces in fig-stiff-starter-conversion.tex
- Change fig-starter-process.tex to use the global "line" style; accept the proposed sidebar syntax.