### PR TITLE
Bring previous commits in line with standards.

### DIFF
--- a/book/figures/fig-starter-process.tex
+++ b/book/figures/fig-starter-process.tex
@@ -33,15 +33,15 @@
   \draw [line] (limitcheck_n) -- node { Yes } (abort_n);
   \draw [line] (readycheck_n) -- node { Yes } (final_n);
 
-  \node [below of=feedok_n, node distance=2cm, align=left] (details2) [shape=rectangle,draw,fill=white!90!black]{
-    \fontsize{7}{9}\selectfont For the \emph{Initial Mixture}, mix \qty{50}{\gram} flour/\qty{50}{\gram} water.\\
-    \fontsize{7}{9}\selectfont The Mixture is \emph{Ready} when it has
+  \node [below of=feedok_n, node distance=2cm, align=left] (details2) [shape=rectangle,draw,fill=maingray]{
+    For the \emph{Initial Mixture}, mix \qty{50}{\gram} flour/\qty{50}{\gram} water.\\
+    The Mixture is \emph{Ready} when it has
     \emph{grown}, has \emph{bubbles}, and \emph{smells}
     vinegary/yoghurty. \\
 
-    \fontsize{7}{9}\selectfont The Mixture has \emph{Failed} when you
-    have fed it too many (eg 10) times without success.\\
+    The Mixture has \emph{Failed} when you
+    have fed it too many (\eg~10) times without success.\\
 
-    \fontsize{7}{9}\selectfont To \emph{Feed the Mixture}, discard all but \qty{10}{\gram}, mix in \qty{50}{\gram} flour and \qty{50}{\gram} water.
+    To \emph{Feed the Mixture}, discard all but \qty{10}{\gram}, mix in \qty{50}{\gram} flour and \qty{50}{\gram} water.
   };
 \end{tikzpicture}

--- a/book/figures/flowcharts_tikz.tex
+++ b/book/figures/flowcharts_tikz.tex
@@ -1,6 +1,6 @@
 \tikzstyle{every picture}+=[font=\footnotesize\sffamily]
-\usetikzlibrary{calc, shapes, arrows, decorations.pathreplacing, calligraphy,
-                positioning, arrows.meta}
+\usetikzlibrary{calc, shapes, arrows.meta, decorations.pathreplacing, calligraphy,
+                positioning}
 \tikzstyle{decision} = [diamond, draw=codeblack, fill=codeblack, text=white,
     text width=4.5em, text badly centered, node distance=3cm, inner sep=0pt,
     line width=2mm]


### PR DESCRIPTION
- Use maingray from colors.tex instead of hardcoded value.
- Remove font size specification in side bar.
- Use \eg to generate e.g. in standard way
- Update flowcharts_tikz.tex to use arrows.meta instead of arrows, rather than in addition to.