### PR TITLE
Correct reference to flowchart in dough strength section

### DIFF
--- a/book/wheat-sourdough/wheat-sourdough.tex
+++ b/book/wheat-sourdough/wheat-sourdough.tex
@@ -615,7 +615,7 @@ by adding water and kneading again. This is a great trick to make
 a more extensible dough with lower-gluten flour~\cite{bassinage+technique}.
 
 When machine kneading a dough, opt for the same technique shown in
-figure~\ref{fig:wheat-sourdough-kneading-process}.  Initially opt for a low
+flowchart~\ref{fig:wheat-sourdough-kneading-process}.  Initially opt for a low
 speed. This helps the homogenization process.
 After waiting to allow the flour to soak up the water, proceed on a higher speed
 setting. A good sign of a well-developed gluten network is


### PR DESCRIPTION
Hi,

in the the "dough strength" section of the wheat sourdough chapter, the section on machine kneading suggests using the same technique as "figure 7.3".

Figure 7.3 does not seem relevant here; there is, however, a _flowchart_ 7.3, which I believe was the intended reference?