### PR TITLE
Same size for all captions

### DIFF
--- a/book/sourdough.sty
+++ b/book/sourdough.sty
@@ -115,6 +115,8 @@
 % Caption and figure size below images
 \usepackage{caption}
 \captionsetup[figure]{font=footnotesize}
+\captionsetup[flowchart]{font=footnotesize}
+\captionsetup[table]{font=footnotesize}
 
 \DeclareSIUnit\degF{\text{°}F}
 


### PR DESCRIPTION
flowchart/table/figures

I ma not sure why we reduced the figures caption font size in the first place?

tree 4b38c6977ac522207d7b5c5615211b98879cefdc
parent 904519db473a86c5f6da66d29a7a16af5ebe6851
author Hendrik Kleinwaechter Fri Dec 30 13:36:14 2022 +0100

Document index page, reduce size of footnotes

Shall we reduce them all or all in normal size?

What do you think?