### PR TITLE
Correct conjuctive/conditional agreement.

### DIFF
--- a/book/wheat-sourdough/wheat-sourdough.tex
+++ b/book/wheat-sourdough/wheat-sourdough.tex
@@ -94,7 +94,7 @@ The starter is what starts the fermentation in your main dough.
 If your starter is off, then your main dough is also going
 to cause trouble during the fermentation. Your starter's
 properties are passed on to your main dough. If your starter
-doesn't have a good balance of yeast to bacteria, so will your
+doesn't have a good balance of yeast to bacteria, neither will your
 main dough.
 
 \begin{flowchart}[!htb]


### PR DESCRIPTION
It's more grammatical in English to replace "So" with "Neither" here.


WARNING: POSSIBLY BORING LANGUAGE REASON AHEAD:

The best way I can think to explain it is that because "so" is a coordinating conjunction here; it's indicating that if P happens, Q will also happen:

```
"If your aliquot sample rises, so will your main dough"

means

P -> Q
```

In this sentence, however, clause P isn't about something happening; It's about something _not_ happening (the dough not having a good balance), it's about `!P -> !Q`

In this case, it's more grammatical to use the negative conjunction "neither".


(Annoying additional English quirk; If you were making definitive statements, neither stops being coordinating!

```
"You don't have a job; neither does your friend" 

means 

!P & !Q
```

But if you add back in the "so" and keep the neither, it becomes coordinating again:

```
"You didn't clean the bathroom, **so neither** did the clerk"

means

"(!P) -> (!Q)"
```
