### PR TITLE
Eliminates duplication

### DIFF
--- a/book/troubleshooting/crumb-structures.tex
+++ b/book/troubleshooting/crumb-structures.tex
@@ -300,7 +300,7 @@ Similar to baking too hot, when baking without enough steam, your dough's crust
 forms too quickly. It's hard to spot the difference between the two mistakes.
 I~typically first ask about the temperature and then about the steaming technique
 to determine what might be wrong with the baking process. Too little steam can
-typically be spotted by having a thick crust around all around your dough paired
+typically be spotted by having a thick crust all around your dough paired
 with large alveoli towards the edges.
 
 The steam essentially prevents the Maillard reaction from happening too quickly


### PR DESCRIPTION
I tripped over the 'around all around' it sounds wrong to me. I propose to either have 'all around' or 'around your'.