### PR TITLE
Fix path line in proofing process figure

### DIFF
--- a/book/figures/fig-proofing-process.tex
+++ b/book/figures/fig-proofing-process.tex
@@ -11,7 +11,7 @@
   \path [line] (init) -- node{No} (retard_bake_decision);
   \path [line] (poke) -- (dent_visible_decision);
   \path [line] (dent_visible_decision) -- node{Yes} (bake);
-  \path [line] (dent_visible_decision.west) -- node{No} (dent_visible_decision.west -| wait_poke.south) -- (wait_poke.south);
+  \path [line] (dent_visible_decision.west) -- node{No} (dent_visible_decision.west -| wait_poke.south) -- node{} (wait_poke.south);
   \path [line] (wait_poke) -- (poke);
   \path [line] (retard_bake_decision) -- node{Yes} (wait_retard);
   \path [line] (retard_bake_decision.east) -- node{No} ++(1, 0) |- node{} (retard.east);

--- a/book/figures/fig-proofing-process.tex
+++ b/book/figures/fig-proofing-process.tex
@@ -11,7 +11,7 @@
   \path [line] (init) -- node{No} (retard_bake_decision);
   \path [line] (poke) -- (dent_visible_decision);
   \path [line] (dent_visible_decision) -- node{Yes} (bake);
-  \path [line] (dent_visible_decision.west) -- node{No} ++(-1.4, 0) -- node{} (wait_poke.south);
+  \path [line] (dent_visible_decision.west) -- node{No} (dent_visible_decision.west -| wait_poke.south) -- (wait_poke.south);
   \path [line] (wait_poke) -- (poke);
   \path [line] (retard_bake_decision) -- node{Yes} (wait_retard);
   \path [line] (retard_bake_decision.east) -- node{No} ++(1, 0) |- node{} (retard.east);


### PR DESCRIPTION
Changed the LaTeX for Flowchart 7.7 to make the arrow corner straight south of the "wait" box.

<img width="632" height="479" alt="image" src="https://github.com/user-attachments/assets/22208d8a-8213-436a-8704-52528d72c11c" />
