### PR TITLE
Improve catalyst wording in enzymatic reactions section

### DIFF
--- a/book/basics/how-sourdough-works.tex
+++ b/book/basics/how-sourdough-works.tex
@@ -30,7 +30,8 @@ When the seed is dry, it is in hibernation mode and can sometimes be
 stored for several years. The moment it comes into contact with water,
 however, it begins to sprout. The seed turns into a germ, requiring the
 stored nutrients to be converted into something the plant can use while
-it grows. The catalyst that makes the associated reactions possible is water.
+it grows. Water is what activates these reactions; the enzymes within the
+seed are the catalysts that drive them.
 
 The seed typically contains the first prototypical leaves of the plant,
 and it can put down roots using the stored nutrients inside. Once those leaves


### PR DESCRIPTION
## What

Reword the description of seed germination in section 2.1 (enzymatic reactions) so that water is described as the **activator** of the reactions rather than the **catalyst**, and the **enzymes** are correctly identified as the catalysts.

Before:

> The catalyst that makes the associated reactions possible is water.

After:

> Water is what activates these reactions; the enzymes within the seed are the catalysts that drive them.

## Why

This came from kind, careful reader feedback. When the seed's stored starch and proteins are broken down (hydrolysis), water is consumed as a reactant — it is not regenerated, so by definition it is not a catalyst. The enzymes are the true catalysts. The new wording is chemically accurate and also reads more naturally into the very next paragraph, which already refers to "the enzymes that trigger this process."

## Credit

Thank you to **Matthijs Velzen** for spotting this and taking the time to write in with such thoughtful, generous feedback. 🙏